### PR TITLE
style: refresh Stats dashboard as an observatory

### DIFF
--- a/docs/plans/2026-09-03-stats-observatory-design.md
+++ b/docs/plans/2026-09-03-stats-observatory-design.md
@@ -1,0 +1,38 @@
+# Stats Observatory Visual Refresh
+
+## Goal
+
+Make the Stats page more memorable without turning the editorial research catalog into a generic dashboard.
+
+## Visual Direction
+
+Keep the existing white-paper canvas, Charter/Georgia typography, restrained blue links, compact KPI rail, and two-row desktop layout. Make `Release trend` the single visual focal point: a deep ink-blue observatory window with a faint technical grid, cool-blue bars, a sage trailing-average line, and quiet corner registration marks.
+
+The remaining category, mechanism, and direction views stay light and editorial so the dark chart reads as deliberate emphasis rather than a site-wide theme change.
+
+## Motion
+
+When the chart first appears or its range changes, bars rise once and the average line draws once. Motion remains brief, communicates the data encoding, and is disabled under `prefers-reduced-motion: reduce`. There is no looping glow, parallax, cursor effect, or decorative animation.
+
+## Architecture and Data
+
+- Reuse the current native SVG renderer and CSS variables in `index.html`.
+- Add no framework, chart library, external font, schema, or data pipeline.
+- Preserve all calculations based on `published_date`, including the latest-data anchor and the 90D/1Y/ALL trailing-average windows.
+- Preserve the existing URL hash, ARIA tabs, native range buttons, loading/error states, category links, and taxonomy drill-down links.
+
+## Responsive and Accessible Behavior
+
+- Keep the 7/5 and 5/7 desktop grid and natural stacked mobile layout.
+- Preserve 44px mobile targets and avoid nested scrolling.
+- Retain SVG title and description content.
+- Keep the chart readable in both system themes; the observatory window remains dark in light mode and uses adjusted contrast in dark mode.
+- Ensure the visual line color matches its accessible description.
+
+## Scope
+
+Modify only `index.html` and the focused Stats source contracts in `tests/test_build.py`. Do not restore removed feeds or explorers, and do not alter catalog data or unrelated site surfaces.
+
+## Verification
+
+Run lightweight source checks and `git diff --check`. Leave the exact focused unit-test and local browser-preview commands for explicit approval under the repository execution policy.

--- a/docs/plans/2026-09-03-stats-observatory.md
+++ b/docs/plans/2026-09-03-stats-observatory.md
@@ -1,0 +1,99 @@
+# Stats Observatory Visual Refresh Implementation Plan
+
+> **For Codex:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Turn the existing Release trend into a focused dark research-observatory visualization while preserving the site's editorial shell and Stats behavior.
+
+**Architecture:** Reuse the final Stats CSS override and native SVG renderer in `index.html`. Add one normalized SVG `pathLength` attribute for reliable line-draw motion, keep all aggregation and interaction code unchanged, and update the existing focused source contract to require the observatory treatment and reduced-motion fallback.
+
+**Tech Stack:** Static HTML, CSS custom properties and keyframes, vanilla JavaScript, native SVG, Python `unittest` source contracts.
+
+---
+
+### Task 1: Specify the observatory contract
+
+**Files:**
+- Modify: `tests/test_build.py:2903-2932`
+
+**Step 1: Replace the obsolete no-animation assertion**
+
+Extend the compact dashboard contract to require:
+
+```python
+self.assertIn("--stats-observatory-bg:", stats_css)
+self.assertIn("animation: stats-bar-rise", stats_css)
+self.assertIn("animation: stats-line-draw", stats_css)
+self.assertIn("@media (prefers-reduced-motion: reduce)", stats_css)
+self.assertIn("animation: none;", stats_css)
+```
+
+Also require `'pathLength': 1` in the release renderer source so the line animation is independent of chart width.
+
+**Step 2: Record the expected failing check**
+
+Do not run the test suite locally without explicit permission. The narrow command for the user or Slurm runner is:
+
+```bash
+python3 -m unittest tests.test_build.TagFilterUiTests.test_stats_dashboard_uses_twelve_column_information_grid
+```
+
+Expected before implementation: FAIL because the observatory variables, animations, and normalized line length do not exist.
+
+### Task 2: Implement the single dark data window
+
+**Files:**
+- Modify: `index.html:4411-4640`
+- Modify: `index.html:5034-5051`
+- Modify: `index.html:5928-5934`
+
+**Step 1: Add local observatory tokens**
+
+Add dark ink, border, text, muted, bar, trend, and grid variables to `.stats-panel` so the treatment remains isolated from Papers and other Stats cards.
+
+**Step 2: Separate the primary chart from generic cards**
+
+Keep `.stats-dashboard-card` transparent and editorial. Give `.stats-primary-chart` the deep ink background, restrained radial light, technical grid, thin border, low radius, and one controlled shadow.
+
+**Step 3: Restyle chart-local typography and controls**
+
+Use light chart text, blue section labels, muted supporting copy, a translucent segmented control, and the existing blue/sage data encoding. Do not change markup or interaction state.
+
+**Step 4: Add meaningful one-shot motion**
+
+Animate bars from the baseline and draw the average line once whenever the native SVG is rebuilt. Add `pathLength="1"` to the polyline and disable both animations under `prefers-reduced-motion: reduce`.
+
+**Step 5: Preserve responsive and dark behavior**
+
+Keep the current grid breakpoints, mobile stacking, 44px controls, and document scrolling. Ensure the final dark-mode override does not reset the observatory window to transparent.
+
+### Task 3: Verify the focused diff
+
+**Files:**
+- Verify: `index.html`
+- Verify: `tests/test_build.py`
+
+**Step 1: Run lightweight source assertions**
+
+Use `rg`/`sed` to confirm the observatory variables, data colors, `pathLength`, animation names, and reduced-motion override are present in the final cascade.
+
+**Step 2: Check patch integrity**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors; only the design/plan documents, `index.html`, and the focused test file are changed.
+
+**Step 3: Leave opt-in verification commands**
+
+Do not execute these locally without explicit permission:
+
+```bash
+python3 -m unittest tests.test_build.TagFilterUiTests.test_stats_dashboard_uses_twelve_column_information_grid
+python3 -m http.server 8123 --bind 127.0.0.1
+```
+
+Browser target: `http://127.0.0.1:8123/index.html#stats`, checked at desktop and 390px mobile widths with light, dark, and reduced-motion preferences.

--- a/index.html
+++ b/index.html
@@ -4556,6 +4556,23 @@
       overflow: hidden;
     }
 
+    .stats-primary-chart::after {
+      position: absolute;
+      inset: 8px;
+      background:
+        linear-gradient(var(--stats-observatory-bar) 0 0) top left / 12px 1px no-repeat,
+        linear-gradient(var(--stats-observatory-bar) 0 0) top left / 1px 12px no-repeat,
+        linear-gradient(var(--stats-observatory-bar) 0 0) top right / 12px 1px no-repeat,
+        linear-gradient(var(--stats-observatory-bar) 0 0) top right / 1px 12px no-repeat,
+        linear-gradient(var(--stats-observatory-bar) 0 0) bottom left / 12px 1px no-repeat,
+        linear-gradient(var(--stats-observatory-bar) 0 0) bottom left / 1px 12px no-repeat,
+        linear-gradient(var(--stats-observatory-bar) 0 0) bottom right / 12px 1px no-repeat,
+        linear-gradient(var(--stats-observatory-bar) 0 0) bottom right / 1px 12px no-repeat;
+      content: '';
+      opacity: 0.38;
+      pointer-events: none;
+    }
+
     .stats-card-header {
       margin-bottom: 8px;
     }
@@ -5150,6 +5167,13 @@
         --stats-data-1: #9eb9ca;
         --stats-data-2: #aaa098;
         --stats-data-3: #77736e;
+        --stats-observatory-bg: #0b1422;
+        --stats-observatory-border: #385273;
+        --stats-observatory-grid: rgba(181, 205, 232, 0.14);
+        --stats-observatory-text: #f5f8fc;
+        --stats-observatory-muted: #b8c6d8;
+        --stats-observatory-bar: #75b8ff;
+        --stats-observatory-trend: #86e2ad;
       }
 
       .stats-dashboard-card,

--- a/index.html
+++ b/index.html
@@ -4416,6 +4416,13 @@
       --stats-data-1: #315f78;
       --stats-data-2: #7f756c;
       --stats-data-3: #a39a90;
+      --stats-observatory-bg: #0f1929;
+      --stats-observatory-border: #2b405d;
+      --stats-observatory-grid: rgba(170, 194, 222, 0.12);
+      --stats-observatory-text: #f4f8ff;
+      --stats-observatory-muted: #aab8ca;
+      --stats-observatory-bar: #65aefc;
+      --stats-observatory-trend: #77dfa6;
       background: transparent;
       padding: 0;
     }
@@ -4536,7 +4543,17 @@
     }
 
     .stats-primary-chart {
-      padding-top: 14px;
+      padding: 18px 18px 0;
+      border: 1px solid var(--stats-observatory-border);
+      border-radius: 6px;
+      background:
+        radial-gradient(circle at 86% -18%, rgba(101, 174, 252, 0.18), transparent 38%),
+        repeating-linear-gradient(0deg, var(--stats-observatory-grid) 0 1px, transparent 1px 32px),
+        repeating-linear-gradient(90deg, var(--stats-observatory-grid) 0 1px, transparent 1px 32px),
+        var(--stats-observatory-bg);
+      color: var(--stats-observatory-text);
+      box-shadow: 0 14px 30px rgba(15, 25, 41, 0.16);
+      overflow: hidden;
     }
 
     .stats-card-header {
@@ -4570,6 +4587,20 @@
       color: var(--text-muted);
     }
 
+    .stats-primary-chart .stats-section-index {
+      color: var(--stats-observatory-bar);
+    }
+
+    .stats-primary-chart .stats-chart-heading h3 {
+      color: var(--stats-observatory-text);
+    }
+
+    .stats-primary-chart .stats-chart-heading p,
+    .stats-primary-chart .stats-chart-legend,
+    .stats-primary-chart .stats-period-summary {
+      color: var(--stats-observatory-muted);
+    }
+
     .stats-range-control,
     .stats-primary-chart .stats-range-control {
       padding: 0;
@@ -4597,6 +4628,36 @@
     .stats-direction-tabs button[aria-pressed="true"] {
       background: var(--text);
       color: var(--bg);
+    }
+
+    .stats-primary-chart .stats-range-control {
+      border-color: var(--stats-observatory-border);
+      background: rgba(255, 255, 255, 0.04);
+    }
+
+    .stats-primary-chart .stats-range-button {
+      color: var(--stats-observatory-muted);
+    }
+
+    .stats-primary-chart .stats-range-button:hover {
+      color: var(--stats-observatory-text);
+    }
+
+    .stats-primary-chart .stats-range-button[aria-pressed="true"] {
+      background: var(--stats-observatory-bar);
+      color: var(--stats-observatory-bg);
+    }
+
+    .stats-primary-chart .stats-range-button:focus-visible {
+      outline-color: var(--stats-observatory-trend);
+    }
+
+    .stats-primary-chart .stats-legend-swatch {
+      background: var(--stats-observatory-bar);
+    }
+
+    .stats-primary-chart .stats-legend-line {
+      border-color: var(--stats-observatory-trend);
     }
 
     .stats-chart-scroll {
@@ -4636,6 +4697,44 @@
 
     .stats-panel .timeline-line {
       stroke: var(--text);
+    }
+
+    .stats-primary-chart .timeline-grid {
+      stroke: var(--stats-observatory-grid);
+    }
+
+    .stats-primary-chart .timeline-axis-label,
+    .stats-primary-chart .timeline-tick-label {
+      fill: var(--stats-observatory-muted);
+    }
+
+    .stats-primary-chart .timeline-axis-count {
+      fill: var(--stats-observatory-bar);
+    }
+
+    .stats-primary-chart .timeline-bar {
+      fill: var(--stats-observatory-bar);
+      opacity: 0.88;
+      transform-box: fill-box;
+      transform-origin: center bottom;
+      animation: stats-bar-rise 560ms cubic-bezier(0.22, 1, 0.36, 1) both;
+    }
+
+    .stats-primary-chart .timeline-line {
+      stroke: var(--stats-observatory-trend);
+      stroke-dasharray: 1;
+      filter: none;
+      animation: stats-line-draw 820ms ease-out 120ms both;
+    }
+
+    @keyframes stats-bar-rise {
+      from { transform: scaleY(0); }
+      to { transform: scaleY(1); }
+    }
+
+    @keyframes stats-line-draw {
+      from { stroke-dashoffset: 1; }
+      to { stroke-dashoffset: 0; }
     }
 
     .stats-category-composition {
@@ -4973,6 +5072,10 @@
         min-height: 44px;
       }
 
+      .stats-primary-chart {
+        padding: 14px 12px 0;
+      }
+
       a.stats-distribution-row {
         min-height: 44px;
         margin: -4px -8px;
@@ -5031,6 +5134,13 @@
       }
     }
 
+    @media (prefers-reduced-motion: reduce) {
+      .stats-primary-chart .timeline-bar,
+      .stats-primary-chart .timeline-line {
+        animation: none;
+      }
+    }
+
     @media (prefers-color-scheme: dark) {
       body > header {
         background: color-mix(in srgb, var(--bg) 92%, transparent);
@@ -5043,9 +5153,7 @@
       }
 
       .stats-dashboard-card,
-      .stats-primary-chart,
-      .stats-metric-rail,
-      .stats-panel .stats-primary-chart {
+      .stats-metric-rail {
         background: transparent;
         box-shadow: none;
       }
@@ -5929,6 +6037,7 @@ function renderReleasePulseChart(container, series, options) {
   });
   svg.appendChild(createStatsSvgElement('polyline', {
     class: 'timeline-line',
+    'pathLength': 1,
     points: averagePoints.join(' ')
   }));
 

--- a/index.html
+++ b/index.html
@@ -4744,6 +4744,11 @@
       animation: stats-line-draw 820ms ease-out 120ms both;
     }
 
+    .stats-primary-chart .timeline-empty {
+      color: var(--stats-observatory-muted);
+      border-color: var(--stats-observatory-border);
+    }
+
     @keyframes stats-bar-rise {
       from { transform: scaleY(0); }
       to { transform: scaleY(1); }

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -2915,11 +2915,30 @@ process.stdout.write(JSON.stringify({{
         dashboard_start = stats_css.index("    .stats-dashboard-grid {")
         dashboard_end = stats_css.index("\n    }", dashboard_start)
         dashboard_rule = stats_css[dashboard_start:dashboard_end]
+        bar_selector = "    .stats-primary-chart .timeline-bar {"
+        bar_start = stats_css.rindex(bar_selector)
+        bar_end = stats_css.index("\n    }", bar_start)
+        bar_rule = stats_css[bar_start:bar_end]
+        line_selector = "    .stats-primary-chart .timeline-line {"
+        line_start = stats_css.rindex(line_selector)
+        line_end = stats_css.index("\n    }", line_start)
+        line_rule = stats_css[line_start:line_end]
         reduced_motion_start = stats_css.rindex("    @media (prefers-reduced-motion: reduce)")
         reduced_motion_end = stats_css.index(
             "    @media (prefers-color-scheme: dark)", reduced_motion_start
         )
         reduced_motion_css = stats_css[reduced_motion_start:reduced_motion_end]
+        reduced_motion_selector = (
+            "      .stats-primary-chart .timeline-bar,\n"
+            "      .stats-primary-chart .timeline-line {"
+        )
+        reduced_motion_rule_start = reduced_motion_css.index(reduced_motion_selector)
+        reduced_motion_rule_end = reduced_motion_css.index(
+            "\n      }", reduced_motion_rule_start
+        )
+        reduced_motion_rule = reduced_motion_css[
+            reduced_motion_rule_start:reduced_motion_rule_end
+        ]
 
         self.assertIn("grid-template-columns: repeat(12, minmax(0, 1fr));", dashboard_rule)
         self.assertIn("align-items: start;", dashboard_rule)
@@ -2938,17 +2957,14 @@ process.stdout.write(JSON.stringify({{
         self.assertIn("background: transparent;", stats_css)
         self.assertIn("border-top: 1px solid var(--border);", stats_css)
         self.assertIn("--stats-observatory-bg:", stats_css)
-        self.assertIn("animation: stats-bar-rise", stats_css)
-        self.assertIn("animation: stats-line-draw", stats_css)
-        self.assertIn("stroke-dasharray: 1;", stats_css)
+        self.assertIn("animation: stats-bar-rise", bar_rule)
+        self.assertIn("stroke-dasharray: 1;", line_rule)
+        self.assertIn("animation: stats-line-draw", line_rule)
         self.assertIn("@keyframes stats-bar-rise", stats_css)
         self.assertIn("@keyframes stats-line-draw", stats_css)
-        self.assertIn(
-            ".stats-primary-chart .timeline-bar,\n"
-            "      .stats-primary-chart .timeline-line {",
-            reduced_motion_css,
-        )
-        self.assertIn("animation: none;", reduced_motion_css)
+        self.assertIn(".stats-primary-chart .timeline-bar,", reduced_motion_rule)
+        self.assertIn(".stats-primary-chart .timeline-line {", reduced_motion_rule)
+        self.assertIn("animation: none;", reduced_motion_rule)
         self.assertIn("@media (max-width: 768px)", stats_css)
         self.assertIn("min-height: 44px;", stats_css)
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -2866,6 +2866,7 @@ process.stdout.write(JSON.stringify({{
         ):
             self.assertIn(marker, timeline_source)
         self.assertIn("setAttribute", timeline_source)
+        self.assertIn("'pathLength': 1", timeline_source)
         self.assertNotIn("innerHTML", timeline_source)
         self.assertNotIn("innerHTML", stats_source)
         self.assertIn("buildDailyPublicationSeries(ALL_PAPERS)", stats_source)
@@ -2927,7 +2928,11 @@ process.stdout.write(JSON.stringify({{
         self.assertIn("height: clamp(220px, 27vh, 250px);", chart_scroll_css)
         self.assertIn("background: transparent;", stats_css)
         self.assertIn("border-top: 1px solid var(--border);", stats_css)
-        self.assertNotIn("animation:", stats_css)
+        self.assertIn("--stats-observatory-bg:", stats_css)
+        self.assertIn("animation: stats-bar-rise", stats_css)
+        self.assertIn("animation: stats-line-draw", stats_css)
+        self.assertIn("@media (prefers-reduced-motion: reduce)", stats_css)
+        self.assertIn("animation: none;", stats_css)
         self.assertIn("@media (max-width: 768px)", stats_css)
         self.assertIn("min-height: 44px;", stats_css)
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -2915,15 +2915,15 @@ process.stdout.write(JSON.stringify({{
         dashboard_start = stats_css.index("    .stats-dashboard-grid {")
         dashboard_end = stats_css.index("\n    }", dashboard_start)
         dashboard_rule = stats_css[dashboard_start:dashboard_end]
+        reduced_motion_start = stats_css.rindex("    @media (prefers-reduced-motion: reduce)")
         bar_selector = "    .stats-primary-chart .timeline-bar {"
-        bar_start = stats_css.rindex(bar_selector)
+        bar_start = stats_css.rindex(bar_selector, 0, reduced_motion_start)
         bar_end = stats_css.index("\n    }", bar_start)
         bar_rule = stats_css[bar_start:bar_end]
         line_selector = "    .stats-primary-chart .timeline-line {"
-        line_start = stats_css.rindex(line_selector)
+        line_start = stats_css.rindex(line_selector, 0, reduced_motion_start)
         line_end = stats_css.index("\n    }", line_start)
         line_rule = stats_css[line_start:line_end]
-        reduced_motion_start = stats_css.rindex("    @media (prefers-reduced-motion: reduce)")
         reduced_motion_end = stats_css.index(
             "    @media (prefers-color-scheme: dark)", reduced_motion_start
         )

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -2865,8 +2865,12 @@ process.stdout.write(JSON.stringify({{
             "renderStatsActiveDirections",
         ):
             self.assertIn(marker, timeline_source)
+        line_start = timeline_source.index("createStatsSvgElement('polyline'")
+        line_end = timeline_source.index("}));", line_start)
+        line_source = timeline_source[line_start:line_end]
         self.assertIn("setAttribute", timeline_source)
-        self.assertIn("'pathLength': 1", timeline_source)
+        self.assertIn("class: 'timeline-line'", line_source)
+        self.assertIn("'pathLength': 1", line_source)
         self.assertNotIn("innerHTML", timeline_source)
         self.assertNotIn("innerHTML", stats_source)
         self.assertIn("buildDailyPublicationSeries(ALL_PAPERS)", stats_source)
@@ -2911,6 +2915,11 @@ process.stdout.write(JSON.stringify({{
         dashboard_start = stats_css.index("    .stats-dashboard-grid {")
         dashboard_end = stats_css.index("\n    }", dashboard_start)
         dashboard_rule = stats_css[dashboard_start:dashboard_end]
+        reduced_motion_start = stats_css.rindex("    @media (prefers-reduced-motion: reduce)")
+        reduced_motion_end = stats_css.index(
+            "    @media (prefers-color-scheme: dark)", reduced_motion_start
+        )
+        reduced_motion_css = stats_css[reduced_motion_start:reduced_motion_end]
 
         self.assertIn("grid-template-columns: repeat(12, minmax(0, 1fr));", dashboard_rule)
         self.assertIn("align-items: start;", dashboard_rule)
@@ -2931,8 +2940,15 @@ process.stdout.write(JSON.stringify({{
         self.assertIn("--stats-observatory-bg:", stats_css)
         self.assertIn("animation: stats-bar-rise", stats_css)
         self.assertIn("animation: stats-line-draw", stats_css)
-        self.assertIn("@media (prefers-reduced-motion: reduce)", stats_css)
-        self.assertIn("animation: none;", stats_css)
+        self.assertIn("stroke-dasharray: 1;", stats_css)
+        self.assertIn("@keyframes stats-bar-rise", stats_css)
+        self.assertIn("@keyframes stats-line-draw", stats_css)
+        self.assertIn(
+            ".stats-primary-chart .timeline-bar,\n"
+            "      .stats-primary-chart .timeline-line {",
+            reduced_motion_css,
+        )
+        self.assertIn("animation: none;", reduced_motion_css)
         self.assertIn("@media (max-width: 768px)", stats_css)
         self.assertIn("min-height: 44px;", stats_css)
 
@@ -3020,11 +3036,18 @@ process.stdout.write(JSON.stringify({{
         ticks_start = stats_css.index("    .stats-panel .timeline-axis-label,")
         ticks_end = stats_css.index("\n    }", ticks_start)
         ticks_rule = stats_css[ticks_start:ticks_end]
+        empty_selector = "    .stats-primary-chart .timeline-empty {"
+        self.assertIn(empty_selector, stats_css)
+        empty_start = stats_css.index(empty_selector)
+        empty_end = stats_css.index("\n    }", empty_start)
+        empty_rule = stats_css[empty_start:empty_end]
 
         self.assertIn("color: var(--text-muted);", note_rule)
         self.assertNotIn("var(--text-dim)", note_rule)
         self.assertIn("fill: var(--text-muted);", ticks_rule)
         self.assertNotIn("var(--text-dim)", ticks_rule)
+        self.assertIn("color: var(--stats-observatory-muted);", empty_rule)
+        self.assertIn("border-color: var(--stats-observatory-border);", empty_rule)
 
     def test_table_header_sort_buttons_exist_for_date_citations_and_stars_with_direction_controls(self):
         html = INDEX_HTML_PATH.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- turn the Release trend into a focused ink-blue observatory panel while preserving the site editorial style
- add technical grid details, registration marks, and restrained one-shot chart motion
- keep the remaining taxonomy panels lightweight, responsive, dark-mode aware, and accessible

## Verification
- 3 focused Stats UI contract tests passed
- verified desktop and 390px layouts with no horizontal overflow
- verified 44px mobile controls, 90D/1Y switching, dark-mode tokens, and reduced-motion fallback