### PR TITLE
Automate paper metrics refresh and add Newly Arrived

### DIFF
--- a/.github/workflows/build-papers.yml
+++ b/.github/workflows/build-papers.yml
@@ -1,8 +1,6 @@
 name: Build generated repo artifacts
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -11,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: read
 
     steps:
@@ -134,23 +132,6 @@ jobs:
           print("No new free-form tags detected.")
           EOF
 
-      - name: Require Semantic Scholar API key
-        if: ${{ github.event_name != 'pull_request' }}
-        env:
-          SEMANTIC_SCHOLAR_API_KEY: ${{ secrets.SEMANTIC_SCHOLAR_API_KEY }}
-        run: |
-          if [ -z "${SEMANTIC_SCHOLAR_API_KEY}" ]; then
-            echo "Missing repository secret: SEMANTIC_SCHOLAR_API_KEY" >&2
-            exit 1
-          fi
-
-      - name: Fetch citation counts and GitHub stars
-        if: ${{ github.event_name != 'pull_request' }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          SEMANTIC_SCHOLAR_API_KEY: ${{ secrets.SEMANTIC_SCHOLAR_API_KEY }}
-        run: python3 scripts/fetch_metrics.py
-
       - name: Build papers.json, submission-meta.json, README.md, and TAGS.md
         run: python3 scripts/build.py
 
@@ -159,13 +140,3 @@ jobs:
 
       - name: Run unit tests
         run: python3 -m unittest discover -s tests -t . -p 'test_*.py'
-
-      - name: Commit metrics and generated files (on main only)
-        if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add papers
-          git add -f papers.json submission-meta.json README.md TAGS.md
-          git diff --cached --quiet || git commit -m "chore: update metrics and generated artifacts [skip ci]"
-          git push

--- a/.github/workflows/update-metrics.yml
+++ b/.github/workflows/update-metrics.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: update-paper-metrics
+  group: update-paper-metrics-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/update-metrics.yml
+++ b/.github/workflows/update-metrics.yml
@@ -1,16 +1,19 @@
 name: Update paper metrics
 
 on:
+  push:
+    branches: [main]
   schedule:
-    - cron: "17 5 * * 1"
+    - cron: "17 5 * * *"
   workflow_dispatch:
 
 concurrency:
   group: update-paper-metrics
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   update-metrics:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -40,10 +43,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SEMANTIC_SCHOLAR_API_KEY: ${{ secrets.SEMANTIC_SCHOLAR_API_KEY }}
-        run: python3 scripts/fetch_metrics.py
+        run: python3 scripts/fetch_metrics.py --strict
 
       - name: Rebuild generated outputs
         run: python3 scripts/build.py
+
+      - name: Check static asset budgets
+        run: python3 scripts/check_asset_budgets.py
+
+      - name: Run unit tests
+        run: python3 -m unittest discover -s tests -t . -p 'test_*.py'
 
       - name: Commit updated metrics
         run: |
@@ -51,5 +60,23 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add papers
           git add -f papers.json submission-meta.json README.md TAGS.md
-          git diff --cached --quiet || git commit -m "chore: update paper metrics [skip ci]"
-          git push
+          git diff --cached --quiet && exit 0
+
+          base_sha="$(git rev-parse HEAD)"
+          git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
+          if [ "$(git rev-parse origin/main)" != "${base_sha}" ]; then
+            echo "::notice::main advanced; a newer push run owns this refresh."
+            exit 0
+          fi
+
+          git commit -m "chore: update paper metrics [skip ci]"
+          if git push origin HEAD:main; then
+            exit 0
+          fi
+
+          git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
+          if [ "$(git rev-parse origin/main)" != "${base_sha}" ]; then
+            echo "::notice::main advanced during push; skipping stale refresh."
+            exit 0
+          fi
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,7 +214,7 @@ Notes for blogs:
 
 Notes for both papers and blogs:
 - `published_date` is required for all papers and blogs; use the original release date and keep it as a quoted `YYYY-MM-DD` string
-- `added_date` is the repo intake date used by the daily feed / Today-style filtering; when included, keep it as a quoted `YYYY-MM-DD` string
+- `added_date` is the repo intake date used by the daily feed; the greatest valid paper value defines the `Newly Arrived` batch, while blogs are excluded from that filter; when included, keep it as a quoted `YYYY-MM-DD` string
 
 ### Filename Rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,7 +214,7 @@ Notes for blogs:
 
 Notes for both papers and blogs:
 - `published_date` is required for all papers and blogs; use the original release date and keep it as a quoted `YYYY-MM-DD` string
-- `added_date` is the repo intake date used by the daily feed; the greatest valid paper value defines the `Newly Arrived` batch, while blogs are excluded from that filter; when included, keep it as a quoted `YYYY-MM-DD` string
+- `added_date` is required for papers and optional for blogs; it is the repo intake date used by the daily feed, and the greatest valid paper value defines the `Newly Arrived` batch while blogs are excluded; keep it as a quoted `YYYY-MM-DD` string
 
 ### Filename Rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,7 +214,7 @@ Notes for blogs:
 
 Notes for both papers and blogs:
 - `published_date` is required for all papers and blogs; use the original release date and keep it as a quoted `YYYY-MM-DD` string
-- `added_date` is required for papers and optional for blogs; it is the repo intake date used by the daily feed, and the greatest valid paper value defines the `Newly Arrived` batch while blogs are excluded; keep it as a quoted `YYYY-MM-DD` string
+- `added_date` is required for new paper entries and optional for blogs; it is the repo intake date used by the daily feed, and the greatest valid paper value defines the `Newly Arrived` batch while blogs are excluded; keep it as a quoted `YYYY-MM-DD` string
 
 ### Filename Rules
 

--- a/assets/daily-watch-countdown.js
+++ b/assets/daily-watch-countdown.js
@@ -3,7 +3,7 @@
 
   // Shared schedule metadata for the public-facing countdown.
   const DAILY_WATCH_TIME_ZONE = 'America/New_York';
-  const DAILY_WATCH_SCHEDULE = { hour: 20, minute: 5, activeWeekdays: [0, 1, 2, 3, 4] };
+  const DAILY_WATCH_SCHEDULE = { hour: 20, minute: 15, activeWeekdays: [0, 1, 2, 3, 4] };
   const DAILY_WATCH_WEEKDAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
   const DAILY_WATCH_WEEKDAY_INDEX = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
 
@@ -137,15 +137,15 @@
     const nextRun = computeNextDailyWatchRun(now);
     if (!nextRun) {
       valueEl.textContent = 'Schedule unavailable';
-      metaEl.textContent = '20:05 ET Sunday–Thursday · about 5 minutes after arXiv\'s daily announcement.';
+      metaEl.textContent = '20:15 ET Sunday–Thursday · about 15 minutes after arXiv\'s daily announcement.';
       return null;
     }
 
     const remainingMs = nextRun.date.getTime() - now.getTime();
     valueEl.textContent = 'in ' + formatCountdownDuration(remainingMs);
-    metaEl.textContent = '20:05 ET Sunday–Thursday · next fetch '
+    metaEl.textContent = '20:15 ET Sunday–Thursday · next paper watch '
       + formatDailyWatchRunLabel(nextRun)
-      + ' · about 5 minutes after arXiv\'s daily announcement.';
+      + ' · about 15 minutes after arXiv\'s daily announcement.';
     return nextRun;
   }
 

--- a/blogs/_template.yaml.example
+++ b/blogs/_template.yaml.example
@@ -56,6 +56,7 @@ links:
 # - `links.blog` is required for blogs.
 # - `published_date` is required for all blogs. Use the original release date
 #   and keep it as a quoted `YYYY-MM-DD` string.
-# - `added_date` is the repo intake date used by the daily feed / Today-style
-#   filtering; when present, keep it as a quoted `YYYY-MM-DD` string.
+# - `added_date` is the repo intake date used by the daily feed; blogs are
+#   excluded from `Newly Arrived`. When present, keep it as a quoted
+#   `YYYY-MM-DD` string.
 # - Blogs do not use `category`, `category_path`, or `foundation`.

--- a/docs/plans/2026-09-03-catalog-refresh-automation-design.md
+++ b/docs/plans/2026-09-03-catalog-refresh-automation-design.md
@@ -1,0 +1,138 @@
+# Catalog Refresh Automation Design
+
+## Goal
+
+Keep quantitative paper metrics and the metadata behind the catalog's quick
+filters current without treating uncertain web evidence as canonical data.
+Replace the date-bound `Today` filter with `Newly Arrived`, meaning the papers
+from the catalog's newest intake batch.
+
+## Current Problems
+
+- `Update paper metrics` runs only weekly, while ordinary `main` pushes run a
+  second copy of the same fetch-and-write path.
+- Both workflows can write directly to `main`; concurrent merges have already
+  produced a non-fast-forward bot push.
+- Citation-source outages are fail-soft. Old metric values survive, but partial
+  results can erase provenance and still make a run look fresh.
+- The four quick filters read curated YAML metadata, not citation/star metrics:
+  `venue`, `published_date`, `links.github` / `links.hf`, and comments.
+- `Today` is anchored to the last build date and paper publication date, so its
+  name does not describe a stable catalog-intake concept.
+- The public countdown says `20:05 ET`, while the active daily watch runs at
+  `20:15 ET` Sunday through Thursday.
+
+## Selected Architecture
+
+Use two deliberately different automation paths.
+
+### Objective metrics: one repository writer
+
+Make the existing metrics workflow the only workflow that fetches and writes
+citations, GitHub stars, and generated catalog artifacts. It runs:
+
+- once per day;
+- after a push to `main`, so newly merged papers do not wait for the next day;
+- on manual dispatch.
+
+Runs share one cancel-in-progress concurrency group. A newer `main` snapshot
+supersedes an older run, and the writer checks that `main` has not advanced
+before committing. The ordinary build workflow remains validation-only and no
+longer fetches metrics or pushes a bot commit.
+
+The metrics fetch keeps old values and old source provenance when a source is
+temporarily unavailable. CI strict mode fails before writing when a paper with
+a previously known citation or star value receives no fresh value from any
+eligible source. A successful generated timestamp therefore represents a
+completed metric check rather than merely a completed static build.
+
+No persistent Actions cache is added. The current cache TTLs would make a
+daily job reuse citation data for seven days and star data for three days,
+which conflicts with the requested daily freshness.
+
+### Curated status metadata: evidence-reviewed PRs
+
+Extend the existing daily Awesome Loop Models watch instead of adding a second
+semantic crawler. Each Sunday-through-Thursday run still discovers new papers
+and additionally audits one stable weekday shard of existing papers. Across
+one active week, every paper is reconsidered for:
+
+- a verified venue/acceptance change;
+- an official GitHub or Hugging Face code link;
+- a concrete public community-comment URL.
+
+Only exact primary or first-party evidence can change canonical YAML. Ambiguous
+matches, inaccessible sources, and search-only guesses are reported and
+skipped. Verified metadata changes join the daily review branch and pull
+request; they never write directly to `main` or merge automatically. A no-op
+audit creates no repository churn.
+
+### Newly Arrived filter
+
+Rename `Today` to `Newly Arrived`. At catalog load time, compute the greatest
+valid `added_date` among papers. The filter includes only papers whose
+`added_date` equals that value.
+
+This reuses existing canonical data and needs no new flag, manifest, timestamp,
+or time-zone logic. It means "the newest batch present in this catalog," even
+when a scheduled watch or human review finishes late. Blogs remain excluded.
+
+The countdown is updated to the actual `20:15 ET` daily-watch schedule. It
+describes paper discovery, not the separate metrics refresh.
+
+## Data Flow
+
+```text
+Semantic Scholar / OpenAlex / OpenCitations / Crossref / GitHub
+    -> daily repository metrics workflow
+    -> strict freshness guard
+    -> papers/*.yaml + generated artifacts
+    -> bot commit on current main
+
+Daily research watch
+    -> new-paper discovery + one stable metadata-audit shard
+    -> exact-source verification
+    -> review branch and PR when canonical metadata changes
+
+papers/*.yaml added_date
+    -> scripts/build.py
+    -> papers.json
+    -> max added_date
+    -> Newly Arrived filter
+```
+
+## Failure Handling
+
+- A transient metrics-source failure preserves the last known value and
+  provenance.
+- Missing fresh coverage for previously known metrics fails the writer before
+  commit; the old published snapshot stays intact and GitHub Actions reports
+  the failure.
+- If `main` advances during a refresh, the stale run exits without pushing and
+  the newer push-triggered run owns the refresh.
+- An uncertain venue, code, or comment match never changes YAML.
+- A failed or no-op semantic audit does not change the `Newly Arrived` batch.
+
+## Verification
+
+Add focused coverage for:
+
+- latest-`added_date` selection and `Newly Arrived` filter behavior;
+- the renamed control, active-filter label, and removal of `Today` state;
+- preservation of old values/provenance on partial source failure;
+- strict-mode failure when a previously known metric has no fresh result;
+- workflow triggers, single-writer behavior, concurrency, and the stale-HEAD
+  guard;
+- the countdown's `20:15 ET` schedule.
+
+Local work is limited to lightweight source inspection and `git diff --check`.
+The full build and unit suite run in GitHub Actions under the repository's
+shared-cluster execution policy.
+
+## Scope Boundaries
+
+- Do not auto-infer acceptance from a generic API venue string.
+- Do not scrape Google Scholar or fabricate comment links.
+- Do not add a database, service, dependency, third metrics workflow, or
+  per-paper audit timestamp.
+- Do not auto-merge semantic metadata updates.

--- a/docs/plans/2026-09-03-catalog-refresh-automation.md
+++ b/docs/plans/2026-09-03-catalog-refresh-automation.md
@@ -92,7 +92,10 @@ if fresh_citation_sources:
         for value in (*new_citation_sources.values(), legacy_citations)
         if value is not None
     )
-    best_citation_source = _best_citation_source(new_citation_sources)
+    if max(new_citation_sources.values()) == new_citations:
+        best_citation_source = _best_citation_source(new_citation_sources)
+    else:
+        best_citation_source = None
 
 fresh_star_sources = star_source_maps.get(stem, {})
 if fresh_star_sources:

--- a/docs/plans/2026-09-03-catalog-refresh-automation.md
+++ b/docs/plans/2026-09-03-catalog-refresh-automation.md
@@ -1,0 +1,464 @@
+# Catalog Refresh Automation Implementation Plan
+
+> **For Codex:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Refresh paper metrics daily through one safe repository writer, keep filter metadata under evidence-reviewed automation, and replace `Today` with a newest-intake `Newly Arrived` filter.
+
+**Architecture:** Keep the existing metrics fetcher and workflows. Add a strict pre-write guard and fail-soft provenance retention to `scripts/fetch_metrics.py`; make `update-metrics.yml` the only metrics writer; derive `Newly Arrived` directly from the greatest valid paper `added_date`; and extend the existing Codex daily watch with one deterministic metadata-audit shard per run.
+
+**Tech Stack:** Python 3.11, PyYAML, GitHub Actions, vanilla JavaScript, Python `unittest`, Codex local automation.
+
+---
+
+> **Execution constraint:** Do not run builds or test suites on the current machine under the repository's shared-cluster policy. Add tests before implementation, use the commands below in GitHub Actions, and limit local verification to source inspection and `git diff --check` unless the user explicitly authorizes an exact command.
+
+### Task 1: Make metrics refresh fail safely
+
+**Files:**
+- Modify: `tests/test_fetch_metrics.py`
+- Modify: `scripts/fetch_metrics.py:1406-1684`
+
+**Step 1: Add focused failure-mode tests**
+
+Add tests beside the existing `fetch_all` provenance tests:
+
+```python
+def test_fetch_all_preserves_prior_metrics_and_provenance_on_source_failure(self):
+    """A partial or total outage must not erase last-known metric evidence."""
+    # Seed citations/stars, both source maps, best-source fields, and
+    # metrics_updated in one temporary paper YAML.
+    # Return one fresh citation source and no fresh star result.
+    # Assert the fresh source is merged, failed-source provenance survives,
+    # and the star fields plus their old metrics_updated value are retained.
+
+def test_fetch_all_strict_failure_happens_before_any_write(self):
+    """Strict mode must reject missing refresh coverage before persistence."""
+    # Seed citations: 0 and github_stars: 0 so zero is treated as known.
+    # Mock every citation/star fetch as empty and patch both report writers.
+    # Assert RuntimeError names both fields, the YAML is byte-identical,
+    # and neither cache/report writer was called.
+```
+
+In the strict test, also call `fetch_all(strict=True)` for a second paper with no prior metric fields and assert it does not fail merely because the new paper has no result.
+
+**Step 2: Record the expected pre-implementation failures**
+
+CI command; do not run locally:
+
+```bash
+python3 -m unittest tests.test_fetch_metrics
+```
+
+Expected before implementation: `fetch_all()` rejects the `strict` keyword, and outage provenance is removed.
+
+**Step 3: Add strict mode before the first write**
+
+Add `strict: bool = False` to `fetch_all`. Immediately after `fetch_stars_parallel(...)` and before the YAML loop, cache save, or link-report save, add:
+
+```python
+if strict:
+    missing_fresh_metrics = []
+    for paper in papers:
+        stem = paper["stem"]
+        if paper.get("citations") is not None and not citation_source_maps.get(stem):
+            missing_fresh_metrics.append(f"{stem}: citations")
+        if paper.get("github_stars") is not None and not star_source_maps.get(stem):
+            missing_fresh_metrics.append(f"{stem}: github_stars")
+    if missing_fresh_metrics:
+        raise RuntimeError(
+            "Strict metrics refresh failed before write; no fresh value for:\n  - "
+            + "\n  - ".join(missing_fresh_metrics)
+        )
+```
+
+This deliberately guards known fields only. A newly added paper without an established metric remains eligible for the next refresh.
+
+**Step 4: Retain old source evidence with the existing dictionaries**
+
+Inside the per-paper loop, replace the destructive empty-result branches. Reuse ordinary dictionaries; do not add a provenance class or new file:
+
+```python
+old_citation_sources = p.get("citation_sources")
+old_citation_sources = old_citation_sources if isinstance(old_citation_sources, dict) else {}
+new_citation_sources = {
+    **old_citation_sources,
+    **citation_source_maps.get(stem, {}),
+}
+new_citations = max(new_citation_sources.values(), default=p.get("citations"))
+best_citation_source = _best_citation_source(new_citation_sources)
+
+old_star_sources = p.get("star_sources")
+old_star_sources = old_star_sources if isinstance(old_star_sources, dict) else {}
+new_star_sources = {
+    **old_star_sources,
+    **star_source_maps.get(stem, {}),
+}
+new_stars = max(new_star_sources.values(), default=p.get("github_stars"))
+best_star_source = _best_star_source(new_star_sources)
+```
+
+Keep the existing field-by-field change detection and `metrics_updated` behavior. When no source returns, these values equal the old YAML, so there is no rewrite and no false freshness date. Remove only the branches that pop source provenance on an empty result.
+
+**Step 5: Expose strict mode in the existing CLI**
+
+```python
+parser.add_argument(
+    "--strict",
+    action="store_true",
+    help="Fail before writing when a previously known metric has no fresh value.",
+)
+```
+
+Pass `strict=args.strict` to `fetch_all(...)`.
+
+**Step 6: Verify in CI and commit**
+
+CI command; do not run locally:
+
+```bash
+python3 -m unittest tests.test_fetch_metrics
+```
+
+```bash
+git add scripts/fetch_metrics.py tests/test_fetch_metrics.py
+git commit -m "fix: preserve metrics across source outages"
+```
+
+### Task 2: Make the metrics workflow the sole writer
+
+**Files:**
+- Modify: `tests/test_asset_budgets.py:359-400`
+- Modify: `.github/workflows/build-papers.yml`
+- Modify: `.github/workflows/update-metrics.yml`
+
+**Step 1: Rewrite workflow contract tests**
+
+Keep one test for each workflow:
+
+```python
+def test_build_workflow_is_read_only_pull_request_validation(self):
+    """Catalog CI must validate PRs without network metric fetches or writes."""
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    triggers = workflow[True]
+    steps = workflow["jobs"]["build"]["steps"]
+    names = {step["name"] for step in steps}
+
+    self.assertEqual(set(triggers), {"pull_request", "workflow_dispatch"})
+    self.assertEqual(workflow["jobs"]["build"]["permissions"]["contents"], "read")
+    self.assertNotIn("Require Semantic Scholar API key", names)
+    self.assertNotIn("Fetch citation counts and GitHub stars", names)
+    self.assertFalse(any(name.startswith("Commit ") for name in names))
+
+def test_metric_workflow_is_daily_serialized_main_writer(self):
+    """One guarded workflow must own every metric write to main."""
+    workflow = yaml.safe_load(UPDATE_METRICS_WORKFLOW_PATH.read_text(encoding="utf-8"))
+    triggers = workflow[True]
+    job = workflow["jobs"]["update-metrics"]
+    steps = {step["name"]: step for step in job["steps"]}
+
+    self.assertEqual(triggers["schedule"], [{"cron": "17 5 * * *"}])
+    self.assertEqual(triggers["push"]["branches"], ["main"])
+    self.assertIn("workflow_dispatch", triggers)
+    self.assertEqual(workflow["concurrency"], {
+        "group": "update-paper-metrics",
+        "cancel-in-progress": True,
+    })
+    self.assertEqual(job["if"], "github.ref == 'refs/heads/main'")
+    self.assertIn("--strict", steps["Fetch citation counts and GitHub stars"]["run"])
+    self.assertIn("git rev-parse origin/main", steps["Commit updated metrics"]["run"])
+    self.assertIn("git push origin HEAD:main", steps["Commit updated metrics"]["run"])
+```
+
+Also retain assertions that both workflows run `scripts/build.py`, asset budgets, and the full unittest command, and that the writer stages `papers.json`, `submission-meta.json`, `README.md`, and `TAGS.md`.
+
+**Step 2: Record expected workflow-test failures**
+
+CI command; do not run locally:
+
+```bash
+python3 -m unittest tests.test_asset_budgets
+```
+
+Expected before implementation: the build workflow still writes, the metrics cron is weekly, strict mode is absent, and concurrency does not cancel stale runs.
+
+**Step 3: Reduce `build-papers.yml` to validation**
+
+- Keep only `pull_request` on `main` and `workflow_dispatch` triggers.
+- Change `permissions.contents` from `write` to `read`; retain `pull-requests: read`.
+- Keep YAML validation, new-tag review, offline build, asset budgets, and unit tests.
+- Delete the API-key requirement, metrics fetch, and commit/push steps.
+
+**Step 4: Promote `update-metrics.yml` to the only writer**
+
+Use the existing workflow and steps; do not create another workflow:
+
+```yaml
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 5 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: update-paper-metrics
+  cancel-in-progress: true
+
+jobs:
+  update-metrics:
+    if: github.ref == 'refs/heads/main'
+```
+
+Change the fetch command to `python3 scripts/fetch_metrics.py --strict`. After rebuild, run the existing asset-budget command and full unittest discovery command before staging.
+
+**Step 5: Guard the write against an advanced `main`**
+
+Replace the unconditional commit/push tail with:
+
+```bash
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git add papers
+git add -f papers.json submission-meta.json README.md TAGS.md
+git diff --cached --quiet && exit 0
+
+base_sha="$(git rev-parse HEAD)"
+git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
+if [ "$(git rev-parse origin/main)" != "${base_sha}" ]; then
+  echo "::notice::main advanced; a newer push run owns this refresh."
+  exit 0
+fi
+
+git commit -m "chore: update paper metrics [skip ci]"
+if git push origin HEAD:main; then
+  exit 0
+fi
+
+git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
+if [ "$(git rev-parse origin/main)" != "${base_sha}" ]; then
+  echo "::notice::main advanced during push; skipping stale refresh."
+  exit 0
+fi
+exit 1
+```
+
+Do not add a rebase loop or Actions cache. A true network/auth failure must remain visible; a superseded run exits cleanly.
+
+**Step 6: Verify in CI and commit**
+
+CI command; do not run locally:
+
+```bash
+python3 -m unittest tests.test_asset_budgets
+```
+
+```bash
+git add .github/workflows/build-papers.yml .github/workflows/update-metrics.yml tests/test_asset_budgets.py
+git commit -m "ci: centralize catalog metric refreshes"
+```
+
+### Task 3: Replace `Today` with `Newly Arrived`
+
+**Files:**
+- Modify: `tests/test_build.py:850-900,1580-1640,1708-1725,3043-3072,3193-3202`
+- Modify: `index.html:5161,6327-6336,6581-6620,6960-6970,7443-7525,7580-7710,7845-7860,8117-8125`
+- Modify: `papers/_template.yaml.example:47-50`
+- Modify: `blogs/_template.yaml.example:58-61`
+- Modify: `CONTRIBUTING.md:210-220`
+
+**Step 1: Replace the old date-filter test with one executable behavior check**
+
+Extract `normalizeDateInputValue`, the new latest-date helper, and the matcher into the existing Node subprocess pattern. Assert:
+
+```python
+self.assertEqual(json.loads(output), {
+    "latest": "2026-09-03",
+    "active": [False, False, True, False],
+    "inactive": True,
+})
+```
+
+The fixture should contain an older paper, an invalid-date paper, a newest paper, and a newest-date blog. With the filter active, only the newest paper matches; with it inactive, the blog is not filtered out by this matcher.
+
+Update markup/state assertions to require `newly-arrived-only-toggle`, `NEWLY_ARRIVED_ONLY`, `matchNewlyArrivedOnly`, `toggleNewlyArrivedOnly`, and the label `Newly Arrived`. Add one obsolete-name guard covering `TODAY_ONLY`, `today-only-toggle`, `matchTodayOnly`, and `toggleTodayOnly`. Do not change the separate daily-briefing label `Today`.
+
+**Step 2: Record expected UI-test failures**
+
+CI command; do not run locally:
+
+```bash
+python3 -m unittest tests.test_build
+```
+
+Expected before implementation: the new control/helper is absent and all old quick-filter names remain.
+
+**Step 3: Derive the newest intake batch from existing paper data**
+
+Replace the control with:
+
+```html
+<button type="button" class="sort-btn" id="newly-arrived-only-toggle" aria-pressed="false" onclick="toggleNewlyArrivedOnly()">Newly Arrived</button>
+```
+
+Replace the quick-filter state with:
+
+```javascript
+let NEWLY_ARRIVED_ONLY = false;
+let LATEST_ADDED_DATE = '';
+```
+
+Place one helper immediately after `normalizeDateInputValue` so the Node test can reuse the existing source slice:
+
+```javascript
+/** Return the greatest valid paper intake date, or an empty string. */
+function getLatestAddedDateValue(papers) {
+  return papers.reduce(function(latest, paper) {
+    const addedDate = normalizeDateInputValue(paper && paper.added_date) || '';
+    return addedDate > latest ? addedDate : latest;
+  }, '');
+}
+```
+
+Use it in the renamed matcher:
+
+```javascript
+/** Match papers in the newest catalog intake batch. */
+function matchNewlyArrivedOnly(paper) {
+  return !NEWLY_ARRIVED_ONLY || (
+    paper.entry_type !== 'blog'
+    && Boolean(LATEST_ADDED_DATE)
+    && normalizeDateInputValue(paper.added_date) === LATEST_ADDED_DATE
+  );
+}
+```
+
+After `ALL_PAPERS` is prepared in `buildDOM`, assign:
+
+```javascript
+LATEST_ADDED_DATE = getLatestAddedDateValue(ALL_PAPERS);
+```
+
+Thread the renamed state through reset, matching, active-count, button-state, toggle, active-label (`newly arrived`), and active-filter checks. Delete the quick-filter-only `REPO_TODAY`, `getBrowserTodayString()`, `getRepoTodayString()`, and the `generated_local_date` assignment. Leave `getCurrentDailyWatchDateString()` intact for the daily briefing.
+
+**Step 4: Document the one canonical meaning of `added_date`**
+
+- Paper template: say `added_date` is the repo intake date and the greatest valid paper value defines the `Newly Arrived` batch.
+- Blog template: say `added_date` serves the daily feed; blogs do not participate in `Newly Arrived`.
+- `CONTRIBUTING.md`: repeat those semantics once under the existing date guidance.
+
+Do not add a manifest, per-paper refresh timestamp, or new generated field.
+
+**Step 5: Verify in CI and commit**
+
+CI command; do not run locally:
+
+```bash
+python3 -m unittest tests.test_build
+```
+
+```bash
+git add index.html tests/test_build.py papers/_template.yaml.example blogs/_template.yaml.example CONTRIBUTING.md
+git commit -m "feat: filter the newest catalog intake"
+```
+
+### Task 4: Align the public paper-watch countdown
+
+**Files:**
+- Modify: `tests/test_build.py:3073-3082,3256-3290`
+- Modify: `assets/daily-watch-countdown.js:5-6,139-151`
+- Modify: `index.html:5113-5115`
+
+**Step 1: Update schedule expectations first**
+
+Change the three Node-helper expectations to:
+
+```text
+2026-04-24T00:15:00.000Z / Thu 20:15 ET
+2026-04-27T00:15:00.000Z / Sun 20:15 ET
+2026-01-06T01:15:00.000Z / Mon 20:15 ET
+```
+
+Require `Next paper watch` and `20:15 ET Sunday–Thursday` in the markup test.
+
+**Step 2: Change the existing constant and copy**
+
+- Set `DAILY_WATCH_SCHEDULE.minute` to `15`.
+- Change the static label to `Next paper watch`.
+- Change fallback copy to `20:15 ET Sunday–Thursday · about 15 minutes after arXiv's daily announcement.`
+- Change dynamic copy from `next fetch` to `next paper watch`, keeping the existing computed run label.
+
+This countdown describes discovery/metadata review only; do not mention the separate metrics workflow.
+
+**Step 3: Verify in CI and commit**
+
+CI command; do not run locally:
+
+```bash
+python3 -m unittest tests.test_build.DailyWatchCountdownLogicTests
+```
+
+```bash
+git add assets/daily-watch-countdown.js index.html tests/test_build.py
+git commit -m "fix: align the paper watch countdown"
+```
+
+### Task 5: Extend the existing semantic-review automation
+
+**State:**
+- Update through Codex automation tooling: `hermes-daily-awesome-loop-models-watch`
+- Do not edit `/Users/husky/.codex/automations/.../automation.toml` directly
+
+**Step 1: Re-read the live automation**
+
+Use automation view immediately before the update. Preserve its name, active status, schedule (`20:15 ET`, Sunday-Thursday), model, reasoning effort, project, destination, and unrelated prompt rules.
+
+**Step 2: Update only the prompt's responsibilities**
+
+- Remove metrics fetching for newly added papers. The repository metrics workflow now owns all citation/star writes and its `main` push trigger handles newly merged papers.
+- Add a metadata audit goal for exactly one deterministic shard per run.
+- Assign `papers/*.yaml` by `int(hashlib.sha256(relative_path.encode("utf-8")).hexdigest(), 16) % 5`; map Sunday through Thursday to shards `0` through `4`.
+- For each selected paper, check only: verified venue/acceptance, official GitHub or Hugging Face code link, and concrete public community-comment URL.
+- Require exact primary/first-party evidence. Ambiguous matches, inaccessible evidence, and search snippets are reported but skipped.
+- Put verified changes on the existing daily review branch/PR. A no-op audit creates no commit or PR churn. Never push to `main`, merge, or auto-merge.
+- Keep the offline build/test instructions and add final-report counts for shard, audited papers, verified changes, and skipped uncertain candidates.
+
+Do not add a second automation or modify the recurrence rule.
+
+**Step 3: Verify persisted state**
+
+View the automation again and confirm:
+
+- status remains active;
+- recurrence remains Sunday-Thursday at 20:15 ET;
+- the prompt contains the five-shard metadata audit;
+- the prompt no longer tells the daily watch to call `fetch_metrics.py`.
+
+This task changes app state, not git; no repository commit is expected.
+
+### Task 6: Final integration verification
+
+**Files:**
+- Inspect all files changed in Tasks 1-4
+
+**Step 1: Run lightweight local checks only**
+
+```bash
+git diff --check origin/main...HEAD
+rg -n "TODAY_ONLY|today-only-toggle|matchTodayOnly|toggleTodayOnly|20:05 ET|minute: 5" index.html assets
+git status --short --branch
+git diff --stat origin/main...HEAD
+```
+
+Expected: `git diff --check` is clean; the obsolete-name search returns no matches; only intended files are changed. Negative assertions in tests may still spell the removed names, and the daily briefing's separate reader-facing `Today` text remains.
+
+**Step 2: Let the pull-request workflows run the heavy checks**
+
+GitHub Actions commands represented by the workflows; do not run locally:
+
+```bash
+python3 scripts/build.py
+python3 scripts/check_asset_budgets.py
+python3 -m unittest discover -s tests -t . -p 'test_*.py'
+```
+
+Require the PR checks to pass before merge. After merge, confirm one push-triggered `Update paper metrics` run succeeds and that `Build generated repo artifacts` did not create a direct-main bot commit.

--- a/docs/plans/2026-09-03-catalog-refresh-automation.md
+++ b/docs/plans/2026-09-03-catalog-refresh-automation.md
@@ -156,7 +156,7 @@ def test_metric_workflow_is_daily_serialized_main_writer(self):
     self.assertEqual(triggers["push"]["branches"], ["main"])
     self.assertIn("workflow_dispatch", triggers)
     self.assertEqual(workflow["concurrency"], {
-        "group": "update-paper-metrics",
+        "group": "update-paper-metrics-${{ github.ref }}",
         "cancel-in-progress": True,
     })
     self.assertEqual(job["if"], "github.ref == 'refs/heads/main'")
@@ -197,7 +197,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: update-paper-metrics
+  group: update-paper-metrics-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/docs/plans/2026-09-03-catalog-refresh-automation.md
+++ b/docs/plans/2026-09-03-catalog-refresh-automation.md
@@ -29,7 +29,7 @@ def test_fetch_all_preserves_prior_metrics_and_provenance_on_source_failure(self
     # metrics_updated in one temporary paper YAML.
     # Return one fresh citation source and no fresh star result.
     # Assert the fresh source is merged, failed-source provenance survives,
-    # and the star fields plus their old metrics_updated value are retained.
+    # star fields are retained, and metrics_updated advances for the citation change.
 
 def test_fetch_all_strict_failure_happens_before_any_write(self):
     """Strict mode must reject missing refresh coverage before persistence."""
@@ -78,14 +78,21 @@ This deliberately guards known fields only. A newly added paper without an estab
 Inside the per-paper loop, replace the destructive empty-result branches. Reuse ordinary dictionaries; do not add a provenance class or new file:
 
 ```python
-old_citation_sources = p.get("citation_sources")
-old_citation_sources = old_citation_sources if isinstance(old_citation_sources, dict) else {}
-new_citation_sources = {
-    **old_citation_sources,
-    **citation_source_maps.get(stem, {}),
-}
-new_citations = max(new_citation_sources.values(), default=p.get("citations"))
-best_citation_source = _best_citation_source(new_citation_sources)
+fresh_citation_sources = citation_source_maps.get(stem, {})
+if fresh_citation_sources:
+    old_citation_sources = p.get("citation_sources")
+    old_citation_sources = old_citation_sources if isinstance(old_citation_sources, dict) else {}
+    new_citation_sources = {**old_citation_sources, **fresh_citation_sources}
+    legacy_citations = p.get("citations")
+    if old_citation_sources and legacy_citations is not None:
+        if legacy_citations <= max(old_citation_sources.values()):
+            legacy_citations = None
+    new_citations = max(
+        value
+        for value in (*new_citation_sources.values(), legacy_citations)
+        if value is not None
+    )
+    best_citation_source = _best_citation_source(new_citation_sources)
 
 fresh_star_sources = star_source_maps.get(stem, {})
 if fresh_star_sources:
@@ -416,7 +423,7 @@ Use automation view immediately before the update. Preserve its name, active sta
 - For each selected paper, check only: verified venue/acceptance, official GitHub or Hugging Face code link, and concrete public community-comment URL.
 - Require exact primary/first-party evidence. Ambiguous matches, inaccessible evidence, and search snippets are reported but skipped.
 - Put verified changes on the existing daily review branch/PR. A no-op audit creates no commit or PR churn. Never push to `main`, merge, or auto-merge.
-- Keep the offline build/test instructions and add final-report counts for shard, audited papers, verified changes, and skipped uncertain candidates.
+- Keep the offline build and GitHub Actions test instructions, and add final-report counts for shard, audited papers, verified changes, and skipped uncertain candidates.
 
 Do not add a second automation or modify the recurrence rule.
 

--- a/docs/plans/2026-09-03-catalog-refresh-automation.md
+++ b/docs/plans/2026-09-03-catalog-refresh-automation.md
@@ -73,7 +73,7 @@ if strict:
 
 This deliberately guards known fields only. A newly added paper without an established metric remains eligible for the next refresh.
 
-**Step 4: Retain old source evidence with the existing dictionaries**
+**Step 4: Retain citation evidence and trust the fresh GitHub transport**
 
 Inside the per-paper loop, replace the destructive empty-result branches. Reuse ordinary dictionaries; do not add a provenance class or new file:
 
@@ -87,17 +87,13 @@ new_citation_sources = {
 new_citations = max(new_citation_sources.values(), default=p.get("citations"))
 best_citation_source = _best_citation_source(new_citation_sources)
 
-old_star_sources = p.get("star_sources")
-old_star_sources = old_star_sources if isinstance(old_star_sources, dict) else {}
-new_star_sources = {
-    **old_star_sources,
-    **star_source_maps.get(stem, {}),
-}
-new_stars = max(new_star_sources.values(), default=p.get("github_stars"))
-best_star_source = _best_star_source(new_star_sources)
+fresh_star_sources = star_source_maps.get(stem, {})
+if fresh_star_sources:
+    best_star_source, new_stars = next(iter(fresh_star_sources.items()))
+    new_star_sources = fresh_star_sources
 ```
 
-Keep the existing field-by-field change detection and `metrics_updated` behavior. When no source returns, these values equal the old YAML, so there is no rewrite and no false freshness date. Remove only the branches that pop source provenance on an empty result.
+Citation indexes are independent evidence, so failed-source citation provenance may be retained while a fresh value corrects the same source. GitHub API and HTML are instead primary/fallback transports for one star counter: the transport that succeeds in the current run is authoritative for the aggregate, provenance, and best source. Keep the existing field-by-field change detection and `metrics_updated` behavior. When no GitHub transport returns, preserve the old star fields byte-for-byte and do not advance freshness.
 
 **Step 5: Expose strict mode in the existing CLI**
 

--- a/index.html
+++ b/index.html
@@ -5110,9 +5110,9 @@
       <div class="daily-watch-countdown" id="daily-watch-countdown">
         <span class="daily-watch-clock" aria-hidden="true"></span>
         <div class="daily-watch-countdown-copy">
-          <div class="daily-watch-countdown-label">Next refresh</div>
+          <div class="daily-watch-countdown-label">Next paper watch</div>
           <div class="daily-watch-countdown-value" id="daily-watch-countdown-value">Calculating…</div>
-          <div class="daily-watch-countdown-meta" id="daily-watch-countdown-meta">20:05 ET Sunday–Thursday · about 5 minutes after arXiv's daily announcement.</div>
+          <div class="daily-watch-countdown-meta" id="daily-watch-countdown-meta">20:15 ET Sunday–Thursday · about 15 minutes after arXiv's daily announcement.</div>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -5158,7 +5158,7 @@
           <div class="quick-filter-bar">
             <span class="sort-label">Watch:</span>
             <button type="button" class="sort-btn" id="accepted-only-toggle" aria-pressed="false" onclick="toggleAcceptedOnly()">Accepted only</button>
-            <button type="button" class="sort-btn" id="today-only-toggle" aria-pressed="false" onclick="toggleTodayOnly()">Today</button>
+            <button type="button" class="sort-btn" id="newly-arrived-only-toggle" aria-pressed="false" onclick="toggleNewlyArrivedOnly()">Newly Arrived</button>
             <button type="button" class="sort-btn" id="has-code-toggle" aria-pressed="false" onclick="toggleHasCodeOnly()">w/ code</button>
             <button type="button" class="sort-btn" id="has-comments-toggle" aria-pressed="false" onclick="toggleHasCommentsOnly()">w/ comments</button>
           </div>
@@ -6324,17 +6324,6 @@ function renderMetricsHtml(paper) {
   return parts.length ? '<div class="paper-metrics">' + parts.join('') + '</div>' : '';
 }
 
-function getBrowserTodayString() {
-  const today = new Date();
-  return today.getFullYear()
-    + '-' + String(today.getMonth() + 1).padStart(2, '0')
-    + '-' + String(today.getDate()).padStart(2, '0');
-}
-
-function getRepoTodayString() {
-  return REPO_TODAY || getBrowserTodayString();
-}
-
 /** Return today's America/New_York date from the shared daily-watch helper. */
 function getCurrentDailyWatchDateString() {
   if (!window.DAILY_WATCH_COUNTDOWN
@@ -6596,7 +6585,8 @@ let TAG_FILTER_LOOKUP = {};
 let TAG_FILTER_OPEN = false;
 let TAG_DRILLDOWN_INTERACTIONS_BOUND = false;
 let ACCEPTED_ONLY = false;
-let TODAY_ONLY = false;
+let NEWLY_ARRIVED_ONLY = false;
+let LATEST_ADDED_DATE = '';
 let HAS_CODE_ONLY = false;
 let HAS_COMMENTS_ONLY = false;
 let ACTIVE_TOP_LEVEL_TAB = 'papers';
@@ -6616,7 +6606,6 @@ let CATALOG_GENERATED_AT = '';
 let CURRENT_VIEW = 'category';
 let FILTER_SIDEBAR_OPEN = false;
 let EXPANDED_TABLE_ROWS = new Set();
-let REPO_TODAY = '';
 let RESEARCH_PROMPT_LANGUAGE = 'en';
 let RESEARCH_PROMPT_LAST_TRIGGER = null;
 let RESEARCH_PROMPT_COPY_TIMER = null;
@@ -6962,7 +6951,7 @@ function navigateToTagDrilldown(tagKey) {
   if (startDate) startDate.value = '';
   if (endDate) endDate.value = '';
   ACCEPTED_ONLY = false;
-  TODAY_ONLY = false;
+  NEWLY_ARRIVED_ONLY = false;
   HAS_CODE_ONLY = false;
   HAS_COMMENTS_ONLY = false;
   updateQuickFilterButtons();
@@ -7445,6 +7434,14 @@ function normalizeDateInputValue(raw) {
   return /^\d{4}-\d{2}-\d{2}$/.test(value) ? value : null;
 }
 
+/** Return the greatest valid paper intake date, or an empty string. */
+function getLatestAddedDateValue(papers) {
+  return papers.reduce(function(latest, paper) {
+    const addedDate = normalizeDateInputValue(paper && paper.added_date) || '';
+    return addedDate > latest ? addedDate : latest;
+  }, '');
+}
+
 function getPublicationDateFilter() {
   const startRaw = normalizeDateInputValue(document.getElementById("publication-date-start").value);
   const endRaw = normalizeDateInputValue(document.getElementById("publication-date-end").value);
@@ -7481,8 +7478,13 @@ function matchAcceptedOnly(paper) {
   return !ACCEPTED_ONLY || (paper.entry_type !== 'blog' && paper.venue !== 'arXiv');
 }
 
-function matchTodayOnly(paper) {
-  return !TODAY_ONLY || (getPaperPublicationDateValue(paper) === getRepoTodayString());
+/** Match papers in the newest catalog intake batch. */
+function matchNewlyArrivedOnly(paper) {
+  return !NEWLY_ARRIVED_ONLY || (
+    paper.entry_type !== 'blog'
+    && Boolean(LATEST_ADDED_DATE)
+    && normalizeDateInputValue(paper.added_date) === LATEST_ADDED_DATE
+  );
 }
 
 function matchHasCodeOnly(paper) {
@@ -7503,7 +7505,7 @@ function paperMatchesActiveFilters(paper, query, publicationDateFilter) {
     && paperMatchesTagFilters(paper)
     && paperMatchesQuery(paper, query)
     && matchAcceptedOnly(paper)
-    && matchTodayOnly(paper)
+    && matchNewlyArrivedOnly(paper)
     && matchHasCodeOnly(paper)
     && matchHasCommentsOnly(paper);
 }
@@ -7519,7 +7521,7 @@ function getFilterSidebarActiveCount() {
   let count = ACTIVE_TAG_FILTERS.size;
   if (publicationDateFilter.active) count += 1;
   if (ACCEPTED_ONLY) count += 1;
-  if (TODAY_ONLY) count += 1;
+  if (NEWLY_ARRIVED_ONLY) count += 1;
   if (HAS_CODE_ONLY) count += 1;
   if (HAS_COMMENTS_ONLY) count += 1;
   if (CURRENT_VIEW !== 'category') count += 1;
@@ -7584,7 +7586,7 @@ function setToggleButtonState(id, isActive) {
 
 function updateQuickFilterButtons() {
   setToggleButtonState('accepted-only-toggle', ACCEPTED_ONLY);
-  setToggleButtonState('today-only-toggle', TODAY_ONLY);
+  setToggleButtonState('newly-arrived-only-toggle', NEWLY_ARRIVED_ONLY);
   setToggleButtonState('has-code-toggle', HAS_CODE_ONLY);
   setToggleButtonState('has-comments-toggle', HAS_COMMENTS_ONLY);
   updateFilterSidebarSummary();
@@ -7628,8 +7630,8 @@ function toggleAcceptedOnly() {
   rerenderCurrentResults();
 }
 
-function toggleTodayOnly() {
-  TODAY_ONLY = !TODAY_ONLY;
+function toggleNewlyArrivedOnly() {
+  NEWLY_ARRIVED_ONLY = !NEWLY_ARRIVED_ONLY;
   updateQuickFilterButtons();
   rerenderCurrentResults();
 }
@@ -7697,7 +7699,7 @@ function getActiveFilterLabel(query, publicationDateFilter) {
     }
   }
   if (ACCEPTED_ONLY) labels.push('accepted only');
-  if (TODAY_ONLY) labels.push('today');
+  if (NEWLY_ARRIVED_ONLY) labels.push('newly arrived');
   if (HAS_CODE_ONLY) labels.push('w/ code');
   if (HAS_COMMENTS_ONLY) labels.push('w/ comments');
   if (labels.length === 0 && query) labels.push(query);
@@ -7849,7 +7851,7 @@ function renderAllGrids(q) {
   syncDynamicCounts(filteredPapers);
 
   const hasQuery = Boolean(query);
-  const hasActiveFilter = hasQuery || publicationDateFilter.active || ACTIVE_TAG_FILTERS.size > 0 || ACCEPTED_ONLY || TODAY_ONLY || HAS_CODE_ONLY || HAS_COMMENTS_ONLY;
+  const hasActiveFilter = hasQuery || publicationDateFilter.active || ACTIVE_TAG_FILTERS.size > 0 || ACCEPTED_ONLY || NEWLY_ARRIVED_ONLY || HAS_CODE_ONLY || HAS_COMMENTS_ONLY;
   const total = filteredPapers.length;
   const searchCount = document.getElementById('search-count');
   if (searchCount) {
@@ -8114,7 +8116,6 @@ function renderTreeInto(container) {
 
 // ── Build DOM from papers.json data ──────────────────────────────────────────
 function buildDOM(data) {
-  REPO_TODAY = (data.meta && data.meta.generated_local_date) || '';
   CATALOG_GENERATED_AT = (data.meta && data.meta.generated) || '';
   CATEGORIES = data.categories || {};
   BLOG_SECTION_META = {
@@ -8122,6 +8123,7 @@ function buildDOM(data) {
     desc: (data.meta && data.meta.blog_section_desc) || ''
   };
   ALL_PAPERS = (data.papers || []).map(preparePaperRecord);
+  LATEST_ADDED_DATE = getLatestAddedDateValue(ALL_PAPERS);
   CATALOG_DATA_ERROR = false;
   CATALOG_DATA_READY = true;
   ALL_BLOGS = (data.blogs || []).map(preparePaperRecord);

--- a/papers/_template.yaml.example
+++ b/papers/_template.yaml.example
@@ -44,9 +44,9 @@ must_read: false
 #
 # `published_date` is required for all papers. Use the source-paper
 # release date and keep it as a quoted `YYYY-MM-DD` string.
-# `added_date` is the repo intake date. The greatest valid paper value
-# defines the `Newly Arrived` batch; when present, keep it as a quoted
-# `YYYY-MM-DD` string.
+# `added_date` is required for all papers and records the repo intake date.
+# The greatest valid paper value defines the `Newly Arrived` batch; keep it
+# as a quoted `YYYY-MM-DD` string.
 
 mechanism_tags:
   - "flat-loop"

--- a/papers/_template.yaml.example
+++ b/papers/_template.yaml.example
@@ -44,7 +44,7 @@ must_read: false
 #
 # `published_date` is required for all papers. Use the source-paper
 # release date and keep it as a quoted `YYYY-MM-DD` string.
-# `added_date` is required for all papers and records the repo intake date.
+# `added_date` is required for new paper entries and records the repo intake date.
 # The greatest valid paper value defines the `Newly Arrived` batch; keep it
 # as a quoted `YYYY-MM-DD` string.
 

--- a/papers/_template.yaml.example
+++ b/papers/_template.yaml.example
@@ -44,8 +44,8 @@ must_read: false
 #
 # `published_date` is required for all papers. Use the source-paper
 # release date and keep it as a quoted `YYYY-MM-DD` string.
-# `added_date` is the repo intake date used by the daily feed /
-# Today-style filtering; when present, keep it as a quoted
+# `added_date` is the repo intake date. The greatest valid paper value
+# defines the `Newly Arrived` batch; when present, keep it as a quoted
 # `YYYY-MM-DD` string.
 
 mechanism_tags:

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -601,7 +601,7 @@ def load_papers() -> list[dict]:
             )
         mechanism_tags = merge_mechanism_tags(explicit_mechanism_tags)
         published_date = normalize_required_date_string(data.get("published_date"), "published_date", yaml_file.name)
-        added_date = normalize_optional_date_string(data.get("added_date"), "added_date", yaml_file.name)
+        added_date = normalize_required_date_string(data.get("added_date"), "added_date", yaml_file.name)
         must_read = normalize_must_read_flag(data.get("must_read"))
 
         paper = dict(data)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -601,7 +601,7 @@ def load_papers() -> list[dict]:
             )
         mechanism_tags = merge_mechanism_tags(explicit_mechanism_tags)
         published_date = normalize_required_date_string(data.get("published_date"), "published_date", yaml_file.name)
-        added_date = normalize_required_date_string(data.get("added_date"), "added_date", yaml_file.name)
+        added_date = normalize_optional_date_string(data.get("added_date"), "added_date", yaml_file.name)
         must_read = normalize_must_read_flag(data.get("must_read"))
 
         paper = dict(data)

--- a/scripts/fetch_metrics.py
+++ b/scripts/fetch_metrics.py
@@ -1414,6 +1414,7 @@ def fetch_all(
     use_openalex: bool = True,
     use_opencitations: bool = True,
     use_crossref: bool = True,
+    strict: bool = False,
 ) -> None:
     show_progress = _resolve_progress_enabled(progress)
     cache = _load_metrics_cache(CACHE_FILE)
@@ -1500,6 +1501,19 @@ def fetch_all(
         show_progress=show_progress,
         cache=cache,
     )
+    if strict:
+        missing_fresh_metrics = []
+        for p in papers:
+            stem = p["stem"]
+            if p.get("citations") is not None and not citation_source_maps.get(stem):
+                missing_fresh_metrics.append(f"{stem}: citations")
+            if p.get("github_stars") is not None and not star_source_maps.get(stem):
+                missing_fresh_metrics.append(f"{stem}: github_stars")
+        if missing_fresh_metrics:
+            raise RuntimeError(
+                "Strict metrics refresh failed before write; no fresh value for:\n  - "
+                + "\n  - ".join(missing_fresh_metrics)
+            )
     print(f"      Got stars for {len(stars_map)}/{len(papers)} papers.")
 
     now_str = _utcnow().strftime("%Y-%m-%d")
@@ -1508,11 +1522,15 @@ def fetch_all(
         stem = p["stem"]
         yaml_file = p["_path"]
 
-        new_citations = citations_map.get(stem)
-        new_stars = stars_map.get(stem)
-        new_citation_sources = citation_source_maps.get(stem, {})
+        old_citation_sources = p.get("citation_sources")
+        old_citation_sources = old_citation_sources if isinstance(old_citation_sources, dict) else {}
+        new_citation_sources = {**old_citation_sources, **citation_source_maps.get(stem, {})}
+        new_citations = max(new_citation_sources.values(), default=p.get("citations"))
         best_citation_source = _best_citation_source(new_citation_sources)
-        new_star_sources = star_source_maps.get(stem, {})
+        old_star_sources = p.get("star_sources")
+        old_star_sources = old_star_sources if isinstance(old_star_sources, dict) else {}
+        new_star_sources = {**old_star_sources, **star_source_maps.get(stem, {})}
+        new_stars = max(new_star_sources.values(), default=p.get("github_stars"))
         best_star_source = _best_star_source(new_star_sources)
 
         changed = False
@@ -1526,13 +1544,6 @@ def fetch_all(
             if p.get("citation_source_best") != best_citation_source:
                 p["citation_source_best"] = best_citation_source
                 changed = True
-        else:
-            if "citation_sources" in p:
-                p.pop("citation_sources", None)
-                changed = True
-            if "citation_source_best" in p:
-                p.pop("citation_source_best", None)
-                changed = True
 
         if new_stars is not None:
             if p.get("github_stars") != new_stars:
@@ -1543,13 +1554,6 @@ def fetch_all(
                 changed = True
             if p.get("star_source_best") != best_star_source:
                 p["star_source_best"] = best_star_source
-                changed = True
-        else:
-            if "star_sources" in p:
-                p.pop("star_sources", None)
-                changed = True
-            if "star_source_best" in p:
-                p.pop("star_source_best", None)
                 changed = True
         if changed:
             p["metrics_updated"] = now_str
@@ -1583,6 +1587,11 @@ def fetch_all(
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Fetch citation counts and GitHub stars")
     parser.add_argument("--dry-run", action="store_true", help="Print without writing")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail before writing when a previously known metric has no fresh value.",
+    )
     parser.add_argument(
         "--google-scholar",
         action="store_true",
@@ -1674,4 +1683,5 @@ if __name__ == "__main__":
         use_openalex=args.use_openalex,
         use_opencitations=args.use_opencitations,
         use_crossref=args.use_crossref,
+        strict=args.strict,
     )

--- a/scripts/fetch_metrics.py
+++ b/scripts/fetch_metrics.py
@@ -1384,16 +1384,6 @@ def _best_citation_source(source_counts: dict[str, int]) -> str | None:
     return max(source_counts.items(), key=lambda item: (item[1], -priority.get(item[0], 999)))[0]
 
 
-def _best_star_source(source_counts: dict[str, int]) -> str | None:
-    if not source_counts:
-        return None
-    priority = {
-        "github_api": 0,
-        "github_html": 1,
-    }
-    return max(source_counts.items(), key=lambda item: (item[1], -priority.get(item[0], 999)))[0]
-
-
 def _save_github_link_report(broken_links: list[dict], path: Path = GITHUB_LINK_REPORT_FILE) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
@@ -1555,31 +1545,15 @@ def fetch_all(
 
         fresh_star_sources = star_source_maps.get(stem, {})
         if fresh_star_sources:
-            old_star_sources = p.get("star_sources")
-            old_star_sources = old_star_sources if isinstance(old_star_sources, dict) else {}
-            new_star_sources = {**old_star_sources, **fresh_star_sources}
-            legacy_stars = p.get("github_stars")
-            if old_star_sources and legacy_stars is not None:
-                if legacy_stars <= max(old_star_sources.values()):
-                    legacy_stars = None
-            new_stars = max(
-                value
-                for value in (*new_star_sources.values(), legacy_stars)
-                if value is not None
-            )
-            if max(new_star_sources.values()) == new_stars:
-                best_star_source = _best_star_source(new_star_sources)
-                if p.get("star_source_best") != best_star_source:
-                    p["star_source_best"] = best_star_source
-                    changed = True
-            elif "star_source_best" in p:
-                p.pop("star_source_best")
+            best_star_source, new_stars = next(iter(fresh_star_sources.items()))
+            if p.get("star_source_best") != best_star_source:
+                p["star_source_best"] = best_star_source
                 changed = True
             if p.get("github_stars") != new_stars:
                 p["github_stars"] = new_stars
                 changed = True
-            if p.get("star_sources") != new_star_sources:
-                p["star_sources"] = new_star_sources
+            if p.get("star_sources") != fresh_star_sources:
+                p["star_sources"] = fresh_star_sources
                 changed = True
         if changed:
             p["metrics_updated"] = now_str

--- a/scripts/fetch_metrics.py
+++ b/scripts/fetch_metrics.py
@@ -1522,19 +1522,14 @@ def fetch_all(
         stem = p["stem"]
         yaml_file = p["_path"]
 
-        old_citation_sources = p.get("citation_sources")
-        old_citation_sources = old_citation_sources if isinstance(old_citation_sources, dict) else {}
-        new_citation_sources = {**old_citation_sources, **citation_source_maps.get(stem, {})}
-        new_citations = max(new_citation_sources.values(), default=p.get("citations"))
-        best_citation_source = _best_citation_source(new_citation_sources)
-        old_star_sources = p.get("star_sources")
-        old_star_sources = old_star_sources if isinstance(old_star_sources, dict) else {}
-        new_star_sources = {**old_star_sources, **star_source_maps.get(stem, {})}
-        new_stars = max(new_star_sources.values(), default=p.get("github_stars"))
-        best_star_source = _best_star_source(new_star_sources)
-
         changed = False
-        if new_citations is not None:
+        fresh_citation_sources = citation_source_maps.get(stem, {})
+        if fresh_citation_sources:
+            old_citation_sources = p.get("citation_sources")
+            old_citation_sources = old_citation_sources if isinstance(old_citation_sources, dict) else {}
+            new_citation_sources = {**old_citation_sources, **fresh_citation_sources}
+            new_citations = max(new_citation_sources.values())
+            best_citation_source = _best_citation_source(new_citation_sources)
             if p.get("citations") != new_citations:
                 p["citations"] = new_citations
                 changed = True
@@ -1545,7 +1540,13 @@ def fetch_all(
                 p["citation_source_best"] = best_citation_source
                 changed = True
 
-        if new_stars is not None:
+        fresh_star_sources = star_source_maps.get(stem, {})
+        if fresh_star_sources:
+            old_star_sources = p.get("star_sources")
+            old_star_sources = old_star_sources if isinstance(old_star_sources, dict) else {}
+            new_star_sources = {**old_star_sources, **fresh_star_sources}
+            new_stars = max(new_star_sources.values())
+            best_star_source = _best_star_source(new_star_sources)
             if p.get("github_stars") != new_stars:
                 p["github_stars"] = new_stars
                 changed = True

--- a/scripts/fetch_metrics.py
+++ b/scripts/fetch_metrics.py
@@ -1534,7 +1534,9 @@ def fetch_all(
                 for value in (p.get("citations"), *new_citation_sources.values())
                 if value is not None
             )
-            best_citation_source = _best_citation_source(new_citation_sources)
+            best_citation_source = p.get("citation_source_best")
+            if max(new_citation_sources.values()) == new_citations:
+                best_citation_source = _best_citation_source(new_citation_sources)
             if p.get("citations") != new_citations:
                 p["citations"] = new_citations
                 changed = True
@@ -1555,7 +1557,9 @@ def fetch_all(
                 for value in (p.get("github_stars"), *new_star_sources.values())
                 if value is not None
             )
-            best_star_source = _best_star_source(new_star_sources)
+            best_star_source = p.get("star_source_best")
+            if max(new_star_sources.values()) == new_stars:
+                best_star_source = _best_star_source(new_star_sources)
             if p.get("github_stars") != new_stars:
                 p["github_stars"] = new_stars
                 changed = True
@@ -1574,7 +1578,8 @@ def fetch_all(
                 yaml.dump(write_data, f, allow_unicode=True, sort_keys=False, default_flow_style=False)
             updated += 1
 
-    _save_metrics_cache(cache, CACHE_FILE)
+    if not strict:
+        _save_metrics_cache(cache, CACHE_FILE)
     _save_github_link_report(broken_github_links, GITHUB_LINK_REPORT_FILE)
     if broken_github_links:
         print(f"      Wrote GitHub link report with {len(broken_github_links)} broken link(s) to {GITHUB_LINK_REPORT_FILE}.")

--- a/scripts/fetch_metrics.py
+++ b/scripts/fetch_metrics.py
@@ -1538,17 +1538,19 @@ def fetch_all(
                 for value in (*new_citation_sources.values(), legacy_citations)
                 if value is not None
             )
-            best_citation_source = p.get("citation_source_best")
             if max(new_citation_sources.values()) == new_citations:
                 best_citation_source = _best_citation_source(new_citation_sources)
+                if p.get("citation_source_best") != best_citation_source:
+                    p["citation_source_best"] = best_citation_source
+                    changed = True
+            elif "citation_source_best" in p:
+                p.pop("citation_source_best")
+                changed = True
             if p.get("citations") != new_citations:
                 p["citations"] = new_citations
                 changed = True
             if p.get("citation_sources") != new_citation_sources:
                 p["citation_sources"] = new_citation_sources
-                changed = True
-            if p.get("citation_source_best") != best_citation_source:
-                p["citation_source_best"] = best_citation_source
                 changed = True
 
         fresh_star_sources = star_source_maps.get(stem, {})
@@ -1565,17 +1567,19 @@ def fetch_all(
                 for value in (*new_star_sources.values(), legacy_stars)
                 if value is not None
             )
-            best_star_source = p.get("star_source_best")
             if max(new_star_sources.values()) == new_stars:
                 best_star_source = _best_star_source(new_star_sources)
+                if p.get("star_source_best") != best_star_source:
+                    p["star_source_best"] = best_star_source
+                    changed = True
+            elif "star_source_best" in p:
+                p.pop("star_source_best")
+                changed = True
             if p.get("github_stars") != new_stars:
                 p["github_stars"] = new_stars
                 changed = True
             if p.get("star_sources") != new_star_sources:
                 p["star_sources"] = new_star_sources
-                changed = True
-            if p.get("star_source_best") != best_star_source:
-                p["star_source_best"] = best_star_source
                 changed = True
         if changed:
             p["metrics_updated"] = now_str

--- a/scripts/fetch_metrics.py
+++ b/scripts/fetch_metrics.py
@@ -1528,10 +1528,14 @@ def fetch_all(
             old_citation_sources = p.get("citation_sources")
             old_citation_sources = old_citation_sources if isinstance(old_citation_sources, dict) else {}
             new_citation_sources = {**old_citation_sources, **fresh_citation_sources}
-            # ponytail: counts are best-known snapshots; add per-source timestamps for current-only aggregates.
+            # ponytail: retain only top-level counts unsupported by old sources; timestamps enable current-only values.
+            legacy_citations = p.get("citations")
+            if old_citation_sources and legacy_citations is not None:
+                if legacy_citations <= max(old_citation_sources.values()):
+                    legacy_citations = None
             new_citations = max(
                 value
-                for value in (p.get("citations"), *new_citation_sources.values())
+                for value in (*new_citation_sources.values(), legacy_citations)
                 if value is not None
             )
             best_citation_source = p.get("citation_source_best")
@@ -1552,9 +1556,13 @@ def fetch_all(
             old_star_sources = p.get("star_sources")
             old_star_sources = old_star_sources if isinstance(old_star_sources, dict) else {}
             new_star_sources = {**old_star_sources, **fresh_star_sources}
+            legacy_stars = p.get("github_stars")
+            if old_star_sources and legacy_stars is not None:
+                if legacy_stars <= max(old_star_sources.values()):
+                    legacy_stars = None
             new_stars = max(
                 value
-                for value in (p.get("github_stars"), *new_star_sources.values())
+                for value in (*new_star_sources.values(), legacy_stars)
                 if value is not None
             )
             best_star_source = p.get("star_source_best")

--- a/scripts/fetch_metrics.py
+++ b/scripts/fetch_metrics.py
@@ -1417,7 +1417,7 @@ def fetch_all(
     strict: bool = False,
 ) -> None:
     show_progress = _resolve_progress_enabled(progress)
-    cache = _load_metrics_cache(CACHE_FILE)
+    cache = {"version": CACHE_VERSION, "papers": {}} if strict else _load_metrics_cache(CACHE_FILE)
     papers = load_papers()
     if only:
         filtered = []
@@ -1528,7 +1528,12 @@ def fetch_all(
             old_citation_sources = p.get("citation_sources")
             old_citation_sources = old_citation_sources if isinstance(old_citation_sources, dict) else {}
             new_citation_sources = {**old_citation_sources, **fresh_citation_sources}
-            new_citations = max(new_citation_sources.values())
+            # ponytail: counts are best-known snapshots; add per-source timestamps for current-only aggregates.
+            new_citations = max(
+                value
+                for value in (p.get("citations"), *new_citation_sources.values())
+                if value is not None
+            )
             best_citation_source = _best_citation_source(new_citation_sources)
             if p.get("citations") != new_citations:
                 p["citations"] = new_citations
@@ -1545,7 +1550,11 @@ def fetch_all(
             old_star_sources = p.get("star_sources")
             old_star_sources = old_star_sources if isinstance(old_star_sources, dict) else {}
             new_star_sources = {**old_star_sources, **fresh_star_sources}
-            new_stars = max(new_star_sources.values())
+            new_stars = max(
+                value
+                for value in (p.get("github_stars"), *new_star_sources.values())
+                if value is not None
+            )
             best_star_source = _best_star_source(new_star_sources)
             if p.get("github_stars") != new_stars:
                 p["github_stars"] = new_stars

--- a/scripts/fetch_metrics.py
+++ b/scripts/fetch_metrics.py
@@ -1518,7 +1518,7 @@ def fetch_all(
             old_citation_sources = p.get("citation_sources")
             old_citation_sources = old_citation_sources if isinstance(old_citation_sources, dict) else {}
             new_citation_sources = {**old_citation_sources, **fresh_citation_sources}
-            # ponytail: retain only top-level counts unsupported by old sources; timestamps enable current-only values.
+            # Preserve an aggregate only when the saved per-source counts cannot explain it.
             legacy_citations = p.get("citations")
             if old_citation_sources and legacy_citations is not None:
                 if legacy_citations <= max(old_citation_sources.values()):

--- a/tests/test_asset_budgets.py
+++ b/tests/test_asset_budgets.py
@@ -356,10 +356,23 @@ class AssetBudgetContractTests(unittest.TestCase):
         self.assertIn("assets/favicon.png raw bytes", rendered)
         self.assertIn("Asset budgets: FAIL", rendered)
 
-    def test_workflow_runs_generation_budgets_and_tests_on_pull_requests(self):
-        """PR CI should run offline generation and gates while keeping network and writes guarded."""
+    def test_build_workflow_is_offline_read_only_pull_request_ci(self):
+        """Build CI should validate pull requests without fetching metrics or writing to main."""
         workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
-        steps = workflow["jobs"]["build"]["steps"]
+        self.assertEqual(
+            workflow[True],
+            {
+                "pull_request": {"branches": ["main"]},
+                "workflow_dispatch": None,
+            },
+        )
+
+        job = workflow["jobs"]["build"]
+        self.assertEqual(
+            job["permissions"],
+            {"contents": "read", "pull-requests": "read"},
+        )
+        steps = job["steps"]
         steps_by_name = {step["name"]: step for step in steps}
 
         offline_gate_commands = {
@@ -372,32 +385,91 @@ class AssetBudgetContractTests(unittest.TestCase):
                 self.assertEqual(steps_by_name[name]["run"], command)
                 self.assertNotIn("if", steps_by_name[name])
 
-        for name in (
+        self.assertIn("Validate YAML files", steps_by_name)
+        self.assertIn("Check new free-form tags need review", steps_by_name)
+
+        forbidden_names = (
             "Require Semantic Scholar API key",
             "Fetch citation counts and GitHub stars",
-        ):
+            "Commit metrics and generated files (on main only)",
+        )
+        for name in forbidden_names:
             with self.subTest(step=name):
-                self.assertEqual(
-                    steps_by_name[name]["if"],
-                    "${{ github.event_name != 'pull_request' }}",
-                )
-        commit_condition = steps_by_name["Commit metrics and generated files (on main only)"]["if"]
-        self.assertIn("github.event_name != 'pull_request'", commit_condition)
-        self.assertIn("github.ref == 'refs/heads/main'", commit_condition)
-        self.assertIn(
-            "git add -f papers.json submission-meta.json README.md TAGS.md",
-            steps_by_name["Commit metrics and generated files (on main only)"]["run"],
+                self.assertNotIn(name, steps_by_name)
+
+        serialized_steps = json.dumps(steps, sort_keys=True)
+        self.assertNotIn("SEMANTIC_SCHOLAR_API_KEY", serialized_steps)
+        self.assertNotIn("scripts/fetch_metrics.py", serialized_steps)
+        self.assertNotIn("git commit", serialized_steps)
+        self.assertNotIn("git push", serialized_steps)
+
+    def test_metric_workflow_is_the_single_stale_safe_main_writer(self):
+        """Metric refreshes should run daily and publish only from the current main commit."""
+        workflow = yaml.safe_load(UPDATE_METRICS_WORKFLOW_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(
+            workflow[True],
+            {
+                "push": {"branches": ["main"]},
+                "schedule": [{"cron": "17 5 * * *"}],
+                "workflow_dispatch": None,
+            },
+        )
+        self.assertEqual(
+            workflow["concurrency"],
+            {"group": "update-paper-metrics", "cancel-in-progress": True},
         )
 
-    def test_metric_workflow_commits_submission_metadata(self):
-        """Scheduled rebuilds should publish every generated browser dependency."""
-        workflow = yaml.safe_load(UPDATE_METRICS_WORKFLOW_PATH.read_text(encoding="utf-8"))
-        steps = workflow["jobs"]["update-metrics"]["steps"]
-        commit_step = next(step for step in steps if step["name"] == "Commit updated metrics")
-
+        job = workflow["jobs"]["update-metrics"]
+        self.assertEqual(job["if"], "github.ref == 'refs/heads/main'")
+        self.assertEqual(job["permissions"], {"contents": "write"})
+        steps = job["steps"]
+        steps_by_name = {step["name"]: step for step in steps}
         self.assertIn(
+            "--strict",
+            steps_by_name["Fetch citation counts and GitHub stars"]["run"],
+        )
+        self.assertEqual(
+            steps_by_name["Rebuild generated outputs"]["run"],
+            "python3 scripts/build.py",
+        )
+        self.assertEqual(
+            steps_by_name["Check static asset budgets"]["run"],
+            "python3 scripts/check_asset_budgets.py",
+        )
+        self.assertEqual(
+            steps_by_name["Run unit tests"]["run"],
+            "python3 -m unittest discover -s tests -t . -p 'test_*.py'",
+        )
+        commit_step = next(step for step in steps if step["name"] == "Commit updated metrics")
+        script = commit_step["run"]
+
+        for command in (
+            "git add papers",
             "git add -f papers.json submission-meta.json README.md TAGS.md",
-            commit_step["run"],
+            "git diff --cached --quiet && exit 0",
+            'base_sha="$(git rev-parse HEAD)"',
+            "git commit -m \"chore: update paper metrics [skip ci]\"",
+            "git push origin HEAD:main",
+        ):
+            with self.subTest(command=command):
+                self.assertIn(command, script)
+        self.assertEqual(
+            script.count(
+                "git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'"
+            ),
+            2,
+        )
+        self.assertEqual(
+            script.count('[ "$(git rev-parse origin/main)" != "${base_sha}" ]'),
+            2,
+        )
+        self.assertIn(
+            "::notice::main advanced; a newer push run owns this refresh.",
+            script,
+        )
+        self.assertIn(
+            "::notice::main advanced during push; skipping stale refresh.",
+            script,
         )
 
 

--- a/tests/test_asset_budgets.py
+++ b/tests/test_asset_budgets.py
@@ -416,7 +416,7 @@ class AssetBudgetContractTests(unittest.TestCase):
         )
         self.assertEqual(
             workflow["concurrency"],
-            {"group": "update-paper-metrics", "cancel-in-progress": True},
+            {"group": "update-paper-metrics-${{ github.ref }}", "cancel-in-progress": True},
         )
 
         job = workflow["jobs"]["update-metrics"]

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -3719,6 +3719,7 @@ class LoadPapersRegressionTests(unittest.TestCase):
                         "authors": ["Test Author"],
                         "year": 2026,
                         "published_date": "2026-03-10",
+                        "added_date": "2026-03-11",
                         "venue": "arXiv",
                         "category": "analysis",
                         "mechanism_tags": ["implicit-layer"],
@@ -3777,6 +3778,7 @@ class LoadPapersRegressionTests(unittest.TestCase):
                         "authors": ["Test Author"],
                         "year": 2026,
                         "published_date": "2026-03-10",
+                        "added_date": "2026-03-11",
                         "venue": "arXiv",
                         "category": "designs",
                         "catalog_fit": "adjacent",
@@ -3813,6 +3815,7 @@ class LoadPapersRegressionTests(unittest.TestCase):
                         "title": "Loop Test Paper",
                         "year": 2026,
                         "published_date": "2026-03-10",
+                        "added_date": "2026-03-11",
                         "venue": "arXiv",
                         "category": "analysis",
                         "mechanism_tags": ["flat-loop"],
@@ -3856,6 +3859,31 @@ class LoadPapersRegressionTests(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "missing required published_date"):
                     build.load_papers()
 
+    def test_load_papers_requires_added_date(self):
+        """Reject paper sources without a catalog intake date."""
+        with TemporaryDirectory() as tmpdir:
+            papers_dir = Path(tmpdir)
+            paper_path = papers_dir / "2603.08391.yaml"
+            paper_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "title": "Loop Test Paper",
+                        "year": 2026,
+                        "published_date": "2026-03-10",
+                        "venue": "arXiv",
+                        "category": "analysis",
+                        "mechanism_tags": ["flat-loop"],
+                        "links": {"arxiv": "https://arxiv.org/abs/2603.08391"},
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+
+            with patch.object(build, "PAPERS_DIR", papers_dir):
+                with self.assertRaisesRegex(ValueError, "missing required added_date"):
+                    build.load_papers()
+
     def test_load_papers_preserves_must_read_flag(self):
         with TemporaryDirectory() as tmpdir:
             papers_dir = Path(tmpdir)
@@ -3867,6 +3895,7 @@ class LoadPapersRegressionTests(unittest.TestCase):
                         "authors": ["Test Author"],
                         "year": 2026,
                         "published_date": "2026-03-10",
+                        "added_date": "2026-03-11",
                         "venue": "arXiv",
                         "category": "analysis",
                         "must_read": True,

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -864,7 +864,7 @@ ACTIVE_TAG_FILTERS = new Set(['focus::architecture']);
 publicationDateStart.value = '2025-01-01';
 publicationDateEnd.value = '2026-01-01';
 ACCEPTED_ONLY = true;
-TODAY_ONLY = true;
+NEWLY_ARRIVED_ONLY = true;
 HAS_CODE_ONLY = true;
 HAS_COMMENTS_ONLY = true;
 FILTER_SIDEBAR_OPEN = false;
@@ -877,7 +877,7 @@ const entered = {
   placeholder: searchInput.placeholder,
   query: searchInput.value,
   dates: [publicationDateStart.value, publicationDateEnd.value],
-  quickFilters: [ACCEPTED_ONLY, TODAY_ONLY, HAS_CODE_ONLY, HAS_COMMENTS_ONLY],
+  quickFilters: [ACCEPTED_ONLY, NEWLY_ARRIVED_ONLY, HAS_CODE_ONLY, HAS_COMMENTS_ONLY],
   panels: [FILTER_SIDEBAR_OPEN, TAG_FILTER_OPEN],
   visibleCount: ALL_PAPERS.filter(function(paper) {
     return Array.from(ACTIVE_TAG_FILTERS).every(function(key) { return paper._tagKeySet.has(key); });
@@ -1705,11 +1705,11 @@ setTimeout(function() {
         self.assertIn("'<span class=\"category-node-count\">' + count + '</span>'", html)
         self.assertNotIn("count + ' paper' + (count !== 1 ? 's' : '')", html)
 
-    def test_daily_watch_filter_controls_and_table_view_markup_exist(self):
+    def test_quick_filter_controls_and_table_view_markup_exist(self):
+        """Expose the supported quick filters alongside both catalog views."""
         html = INDEX_HTML_PATH.read_text(encoding="utf-8")
         for snippet in (
             "Accepted only",
-            "Today",
             "w/ code",
             "w/ comments",
             "Category view",
@@ -1718,6 +1718,11 @@ setTimeout(function() {
             "papers-table-body",
         ):
             self.assertIn(snippet, html)
+        self.assertIn(
+            '<button type="button" class="sort-btn" id="newly-arrived-only-toggle" '
+            'aria-pressed="false" onclick="toggleNewlyArrivedOnly()">Newly Arrived</button>',
+            html,
+        )
 
         header_start = html.index('<table class="papers-table" aria-label="Table view of loop-model resources">')
         header_end = html.index("</thead>", header_start)
@@ -3061,14 +3066,39 @@ process.stdout.write(JSON.stringify({{
         self.assertIn("labels.push('w/ code');", html)
         self.assertIn("labels.push('w/ comments');", html)
 
-    def test_today_filter_uses_published_date_not_added_date(self):
+    def test_newly_arrived_filter_uses_latest_valid_added_date(self):
+        """Only papers in the newest valid intake batch match while active."""
         html = INDEX_HTML_PATH.read_text(encoding="utf-8")
-        self.assertIn("function matchTodayOnly(paper) {", html)
-        matcher_start = html.index("function matchTodayOnly(paper) {")
+        date_start = html.index("function normalizeDateInputValue(raw) {")
+        date_end = html.index("function getPublicationDateFilter()", date_start)
+        matcher_start = html.index("function matchNewlyArrivedOnly(paper) {")
         matcher_end = html.index("function matchHasCodeOnly(paper)", matcher_start)
-        matcher_snippet = html[matcher_start:matcher_end]
-        self.assertIn("getPaperPublicationDateValue(paper) === getRepoTodayString()", matcher_snippet)
-        self.assertNotIn("paper.added_date", matcher_snippet)
+
+        script = f"""
+{html[date_start:date_end]}
+let NEWLY_ARRIVED_ONLY = true;
+const papers = [
+  {{ entry_type: 'paper', added_date: '2026-09-01' }},
+  {{ entry_type: 'paper', added_date: 'invalid' }},
+  {{ entry_type: 'paper', added_date: '2026-09-03' }}
+];
+const blog = {{ entry_type: 'blog', added_date: '2026-09-03' }};
+let LATEST_ADDED_DATE = getLatestAddedDateValue(papers);
+{html[matcher_start:matcher_end]}
+const active = papers.concat([blog]).map(matchNewlyArrivedOnly);
+NEWLY_ARRIVED_ONLY = false;
+process.stdout.write(JSON.stringify({{
+  latest: LATEST_ADDED_DATE,
+  active,
+  inactive: matchNewlyArrivedOnly(blog)
+}}));
+"""
+        output = subprocess.check_output(["node", "-e", script], text=True)
+        self.assertEqual(json.loads(output), {
+            "latest": "2026-09-03",
+            "active": [False, False, True, False],
+            "inactive": True,
+        })
 
     def test_daily_watch_countdown_widget_and_schedule_logic_exist(self):
         html = INDEX_HTML_PATH.read_text(encoding="utf-8")
@@ -3190,15 +3220,28 @@ process.stdout.write(JSON.stringify({{
         self.assertIn("const disclosureButton = summaryRow.querySelector('.paper-table-disclosure');", html)
         self.assertIn("if (disclosureButton) disclosureButton.setAttribute('aria-expanded', expanded ? 'true' : 'false');", html)
 
-    def test_daily_watch_filters_and_table_view_have_frontend_hooks(self):
+    def test_quick_filters_and_table_view_have_frontend_hooks(self):
+        """Wire the newest-intake state through the existing filter hooks."""
         html = INDEX_HTML_PATH.read_text(encoding="utf-8")
         self.assertIn("paper.entry_type !== 'blog' && paper.venue !== 'arXiv'", html)
-        self.assertIn("function getRepoTodayString()", html)
-        self.assertIn("generated_local_date", html)
-        self.assertIn("getPaperPublicationDateValue(paper) === getRepoTodayString()", html)
+        self.assertIn("let NEWLY_ARRIVED_ONLY = false;", html)
+        self.assertIn("let LATEST_ADDED_DATE = '';", html)
+        self.assertIn("function getLatestAddedDateValue(papers) {", html)
+        self.assertIn("function matchNewlyArrivedOnly(paper) {", html)
+        self.assertIn("LATEST_ADDED_DATE = getLatestAddedDateValue(ALL_PAPERS);", html)
         self.assertIn("function renderTableView(query, papers)", html)
         self.assertIn("function toggleTableRow(paperId)", html)
         self.assertIn("function setView(view)", html)
+        for obsolete_name in (
+            "TODAY_ONLY",
+            "today-only-toggle",
+            "matchTodayOnly",
+            "toggleTodayOnly",
+        ):
+            self.assertNotIn(obsolete_name, html)
+        self.assertNotIn("function getBrowserTodayString()", html)
+        self.assertNotIn("function getRepoTodayString()", html)
+        self.assertNotIn("let REPO_TODAY = '';", html)
 
     def test_mobile_compact_overrides_apply_after_base_control_styles(self):
         html = INDEX_HTML_PATH.read_text(encoding="utf-8")

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -3719,7 +3719,6 @@ class LoadPapersRegressionTests(unittest.TestCase):
                         "authors": ["Test Author"],
                         "year": 2026,
                         "published_date": "2026-03-10",
-                        "added_date": "2026-03-11",
                         "venue": "arXiv",
                         "category": "analysis",
                         "mechanism_tags": ["implicit-layer"],
@@ -3778,7 +3777,6 @@ class LoadPapersRegressionTests(unittest.TestCase):
                         "authors": ["Test Author"],
                         "year": 2026,
                         "published_date": "2026-03-10",
-                        "added_date": "2026-03-11",
                         "venue": "arXiv",
                         "category": "designs",
                         "catalog_fit": "adjacent",
@@ -3815,7 +3813,6 @@ class LoadPapersRegressionTests(unittest.TestCase):
                         "title": "Loop Test Paper",
                         "year": 2026,
                         "published_date": "2026-03-10",
-                        "added_date": "2026-03-11",
                         "venue": "arXiv",
                         "category": "analysis",
                         "mechanism_tags": ["flat-loop"],
@@ -3859,31 +3856,6 @@ class LoadPapersRegressionTests(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "missing required published_date"):
                     build.load_papers()
 
-    def test_load_papers_requires_added_date(self):
-        """Reject paper sources without a catalog intake date."""
-        with TemporaryDirectory() as tmpdir:
-            papers_dir = Path(tmpdir)
-            paper_path = papers_dir / "2603.08391.yaml"
-            paper_path.write_text(
-                yaml.safe_dump(
-                    {
-                        "title": "Loop Test Paper",
-                        "year": 2026,
-                        "published_date": "2026-03-10",
-                        "venue": "arXiv",
-                        "category": "analysis",
-                        "mechanism_tags": ["flat-loop"],
-                        "links": {"arxiv": "https://arxiv.org/abs/2603.08391"},
-                    },
-                    sort_keys=False,
-                ),
-                encoding="utf-8",
-            )
-
-            with patch.object(build, "PAPERS_DIR", papers_dir):
-                with self.assertRaisesRegex(ValueError, "missing required added_date"):
-                    build.load_papers()
-
     def test_load_papers_preserves_must_read_flag(self):
         with TemporaryDirectory() as tmpdir:
             papers_dir = Path(tmpdir)
@@ -3895,7 +3867,6 @@ class LoadPapersRegressionTests(unittest.TestCase):
                         "authors": ["Test Author"],
                         "year": 2026,
                         "published_date": "2026-03-10",
-                        "added_date": "2026-03-11",
                         "venue": "arXiv",
                         "category": "analysis",
                         "must_read": True,

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1687,7 +1687,7 @@ setTimeout(function() {
         self.assertIn('id="daily-watch-countdown-value">Calculating…</div>', html)
         self.assertIn('<span class="daily-watch-clock" aria-hidden="true"></span>', html)
         self.assertIn('<div class="daily-watch-countdown-copy">', html)
-        self.assertIn('<div class="daily-watch-countdown-label">Next refresh</div>', html)
+        self.assertIn('<div class="daily-watch-countdown-label">Next paper watch</div>', html)
         self.assertNotIn('"briefing countdown"', html)
         self.assertIn(".papers-only-tools > .daily-status-row { order: 2; }", html)
         self.assertIn(".papers-only-tools > .search-wrap { order: 3; }", html)
@@ -3106,7 +3106,7 @@ process.stdout.write(JSON.stringify({{
         self.assertIn('id="daily-watch-countdown"', html)
         self.assertIn('id="daily-watch-countdown-value"', html)
         self.assertIn('id="daily-watch-countdown-meta"', html)
-        self.assertIn("20:05 ET Sunday–Thursday", html)
+        self.assertIn("20:15 ET Sunday–Thursday", html)
         self.assertIn("DAILY_WATCH_COUNTDOWN.startDailyWatchCountdown();", html)
         self.assertIn("DAILY_WATCH_COUNTDOWN.updateDailyWatchCountdown();", html)
         self.assertIn(".daily-watch-countdown", html)
@@ -3314,21 +3314,21 @@ process.stdout.write(JSON.stringify({{
 
     def test_daily_watch_helper_keeps_same_day_fetch_before_cutoff(self):
         result = self.run_daily_watch_helper("2026-04-23T12:00:00-04:00")
-        self.assertEqual(result["iso"], "2026-04-24T00:05:00.000Z")
+        self.assertEqual(result["iso"], "2026-04-24T00:15:00.000Z")
         self.assertEqual(result["weekday"], 4)
-        self.assertEqual(result["label"], "Thu 20:05 ET")
+        self.assertEqual(result["label"], "Thu 20:15 ET")
 
     def test_daily_watch_helper_rolls_thursday_night_to_sunday(self):
         result = self.run_daily_watch_helper("2026-04-23T21:00:00-04:00")
-        self.assertEqual(result["iso"], "2026-04-27T00:05:00.000Z")
+        self.assertEqual(result["iso"], "2026-04-27T00:15:00.000Z")
         self.assertEqual(result["weekday"], 0)
-        self.assertEqual(result["label"], "Sun 20:05 ET")
+        self.assertEqual(result["label"], "Sun 20:15 ET")
 
     def test_daily_watch_helper_handles_standard_time_offset(self):
         result = self.run_daily_watch_helper("2026-01-05T12:00:00-05:00")
-        self.assertEqual(result["iso"], "2026-01-06T01:05:00.000Z")
+        self.assertEqual(result["iso"], "2026-01-06T01:15:00.000Z")
         self.assertEqual(result["weekday"], 1)
-        self.assertEqual(result["label"], "Mon 20:05 ET")
+        self.assertEqual(result["label"], "Mon 20:15 ET")
 
 
 class CanonicalPaperMetadataTests(unittest.TestCase):

--- a/tests/test_fetch_metrics.py
+++ b/tests/test_fetch_metrics.py
@@ -2,9 +2,10 @@ import json
 import ssl
 import unittest
 import urllib.error
-from unittest import mock
+from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest import mock
 
 from scripts import fetch_metrics
 
@@ -308,7 +309,7 @@ class SemanticScholarFetchTests(unittest.TestCase):
         self.assertEqual(cache_data["version"], 1)
 
     def test_fetch_all_preserves_metrics_and_provenance_during_source_outages(self):
-        """Keep last-known metrics when only one old citation source responds."""
+        """Merge a fresh citation while retaining failed-source provenance."""
         with TemporaryDirectory() as tmp_dir:
             papers_dir = Path(tmp_dir) / "papers"
             papers_dir.mkdir()
@@ -341,12 +342,71 @@ class SemanticScholarFetchTests(unittest.TestCase):
                     "GITHUB_LINK_REPORT_FILE",
                     Path(tmp_dir) / "github-links.json",
                 ),
-                mock.patch.object(fetch_metrics, "fetch_citations_semantic_scholar", return_value={}),
                 mock.patch.object(
                     fetch_metrics,
-                    "fetch_citations_openalex",
-                    return_value={"2403.09629": 6},
+                    "fetch_citations_semantic_scholar",
+                    return_value={"2403.09629": 8},
                 ),
+                mock.patch.object(fetch_metrics, "fetch_citations_openalex", return_value={}),
+                mock.patch.object(fetch_metrics, "fetch_citations_opencitations", return_value={}),
+                mock.patch.object(fetch_metrics, "fetch_citations_crossref", return_value={}),
+                mock.patch.object(fetch_metrics, "fetch_stars_parallel", return_value=({}, {}, [])),
+                mock.patch.object(
+                    fetch_metrics,
+                    "_utcnow",
+                    return_value=datetime(2026, 9, 3, tzinfo=timezone.utc),
+                ),
+                mock.patch.object(fetch_metrics, "_save_metrics_cache"),
+                mock.patch.object(fetch_metrics, "_save_github_link_report"),
+            ):
+                fetch_metrics.fetch_all(progress=False)
+
+            updated_bytes = paper_path.read_bytes()
+            updated = fetch_metrics.yaml.safe_load(updated_bytes)
+
+        self.assertNotEqual(updated_bytes, original)
+        self.assertEqual(updated["citations"], 8)
+        self.assertEqual(
+            updated["citation_sources"],
+            {"semantic_scholar": 8, "openalex": 6},
+        )
+        self.assertEqual(updated["citation_source_best"], "semantic_scholar")
+        self.assertEqual(updated["github_stars"], 42)
+        self.assertEqual(
+            updated["star_sources"],
+            {"github_api": 42, "github_html": 41},
+        )
+        self.assertEqual(updated["star_source_best"], "github_api")
+        self.assertEqual(updated["metrics_updated"], "2026-09-03")
+
+    def test_fetch_all_total_outage_leaves_legacy_aggregate_only_yaml_unchanged(self):
+        """Leave aggregate-only legacy metrics byte-stable on total outage."""
+        with TemporaryDirectory() as tmp_dir:
+            papers_dir = Path(tmp_dir) / "papers"
+            papers_dir.mkdir()
+            paper_path = papers_dir / "legacy-paper.yaml"
+            original = (
+                "title: Legacy Paper\n"
+                "year: 2024\n"
+                "links:\n"
+                "  arxiv: https://arxiv.org/abs/2403.09629\n"
+                "  github: https://github.com/owner/repo\n"
+                "citations: 7\n"
+                "github_stars: 42\n"
+                "metrics_updated: '2026-08-01'\n"
+            ).encode()
+            paper_path.write_bytes(original)
+
+            with (
+                mock.patch.object(fetch_metrics, "PAPERS_DIR", papers_dir),
+                mock.patch.object(fetch_metrics, "CACHE_FILE", Path(tmp_dir) / "cache.json"),
+                mock.patch.object(
+                    fetch_metrics,
+                    "GITHUB_LINK_REPORT_FILE",
+                    Path(tmp_dir) / "github-links.json",
+                ),
+                mock.patch.object(fetch_metrics, "fetch_citations_semantic_scholar", return_value={}),
+                mock.patch.object(fetch_metrics, "fetch_citations_openalex", return_value={}),
                 mock.patch.object(fetch_metrics, "fetch_citations_opencitations", return_value={}),
                 mock.patch.object(fetch_metrics, "fetch_citations_crossref", return_value={}),
                 mock.patch.object(fetch_metrics, "fetch_stars_parallel", return_value=({}, {}, [])),
@@ -360,18 +420,12 @@ class SemanticScholarFetchTests(unittest.TestCase):
 
         self.assertEqual(updated_bytes, original)
         self.assertEqual(updated["citations"], 7)
-        self.assertEqual(
-            updated["citation_sources"],
-            {"semantic_scholar": 7, "openalex": 6},
-        )
-        self.assertEqual(updated["citation_source_best"], "semantic_scholar")
         self.assertEqual(updated["github_stars"], 42)
-        self.assertEqual(
-            updated["star_sources"],
-            {"github_api": 42, "github_html": 41},
-        )
-        self.assertEqual(updated["star_source_best"], "github_api")
         self.assertEqual(updated["metrics_updated"], "2026-08-01")
+        self.assertNotIn("citation_sources", updated)
+        self.assertNotIn("citation_source_best", updated)
+        self.assertNotIn("star_sources", updated)
+        self.assertNotIn("star_source_best", updated)
 
     def test_fetch_all_strict_fails_before_writes_for_known_zero_metrics(self):
         """Treat zero as known and abort strict refreshes before any write."""

--- a/tests/test_fetch_metrics.py
+++ b/tests/test_fetch_metrics.py
@@ -412,7 +412,13 @@ class SemanticScholarFetchTests(unittest.TestCase):
                 "  arxiv: https://arxiv.org/abs/2403.09630\n"
                 "  github: https://github.com/owner/outage\n"
                 "citations: 3\n"
+                "citation_sources:\n"
+                "  semantic_scholar: 3\n"
+                "citation_source_best: semantic_scholar\n"
                 "github_stars: 5\n"
+                "star_sources:\n"
+                "  github_api: 5\n"
+                "star_source_best: github_api\n"
                 "metrics_updated: '2026-08-02'\n"
             ).encode()
             outage_path.write_bytes(outage_original)
@@ -490,10 +496,10 @@ class SemanticScholarFetchTests(unittest.TestCase):
         self.assertEqual(updated["metrics_updated"], "2026-09-03")
         self.assertEqual(outage_bytes, outage_original)
         self.assertEqual(outage["metrics_updated"], "2026-08-02")
-        self.assertNotIn("citation_sources", outage)
-        self.assertNotIn("citation_source_best", outage)
-        self.assertNotIn("star_sources", outage)
-        self.assertNotIn("star_source_best", outage)
+        self.assertEqual(outage["citation_sources"], {"semantic_scholar": 3})
+        self.assertEqual(outage["citation_source_best"], "semantic_scholar")
+        self.assertEqual(outage["star_sources"], {"github_api": 5})
+        self.assertEqual(outage["star_source_best"], "github_api")
         self.assertNotEqual(unsupported_bytes, unsupported_original)
         self.assertEqual(unsupported["citations"], 10)
         self.assertEqual(unsupported["citation_sources"], {"semantic_scholar": 7})

--- a/tests/test_fetch_metrics.py
+++ b/tests/test_fetch_metrics.py
@@ -307,6 +307,156 @@ class SemanticScholarFetchTests(unittest.TestCase):
         self.assertEqual(updated["citation_source_best"], "openalex")
         self.assertEqual(cache_data["version"], 1)
 
+    def test_fetch_all_preserves_metrics_and_provenance_during_source_outages(self):
+        """Keep last-known metrics when only one old citation source responds."""
+        with TemporaryDirectory() as tmp_dir:
+            papers_dir = Path(tmp_dir) / "papers"
+            papers_dir.mkdir()
+            paper_path = papers_dir / "2403.09629.yaml"
+            original = (
+                "title: Test Paper\n"
+                "year: 2024\n"
+                "links:\n"
+                "  arxiv: https://arxiv.org/abs/2403.09629\n"
+                "  github: https://github.com/owner/repo\n"
+                "citations: 7\n"
+                "citation_sources:\n"
+                "  semantic_scholar: 7\n"
+                "  openalex: 6\n"
+                "citation_source_best: semantic_scholar\n"
+                "github_stars: 42\n"
+                "star_sources:\n"
+                "  github_api: 42\n"
+                "  github_html: 41\n"
+                "star_source_best: github_api\n"
+                "metrics_updated: '2026-08-01'\n"
+            ).encode()
+            paper_path.write_bytes(original)
+
+            with (
+                mock.patch.object(fetch_metrics, "PAPERS_DIR", papers_dir),
+                mock.patch.object(fetch_metrics, "CACHE_FILE", Path(tmp_dir) / "cache.json"),
+                mock.patch.object(
+                    fetch_metrics,
+                    "GITHUB_LINK_REPORT_FILE",
+                    Path(tmp_dir) / "github-links.json",
+                ),
+                mock.patch.object(fetch_metrics, "fetch_citations_semantic_scholar", return_value={}),
+                mock.patch.object(
+                    fetch_metrics,
+                    "fetch_citations_openalex",
+                    return_value={"2403.09629": 6},
+                ),
+                mock.patch.object(fetch_metrics, "fetch_citations_opencitations", return_value={}),
+                mock.patch.object(fetch_metrics, "fetch_citations_crossref", return_value={}),
+                mock.patch.object(fetch_metrics, "fetch_stars_parallel", return_value=({}, {}, [])),
+                mock.patch.object(fetch_metrics, "_save_metrics_cache"),
+                mock.patch.object(fetch_metrics, "_save_github_link_report"),
+            ):
+                fetch_metrics.fetch_all(progress=False)
+
+            updated_bytes = paper_path.read_bytes()
+            updated = fetch_metrics.yaml.safe_load(updated_bytes)
+
+        self.assertEqual(updated_bytes, original)
+        self.assertEqual(updated["citations"], 7)
+        self.assertEqual(
+            updated["citation_sources"],
+            {"semantic_scholar": 7, "openalex": 6},
+        )
+        self.assertEqual(updated["citation_source_best"], "semantic_scholar")
+        self.assertEqual(updated["github_stars"], 42)
+        self.assertEqual(
+            updated["star_sources"],
+            {"github_api": 42, "github_html": 41},
+        )
+        self.assertEqual(updated["star_source_best"], "github_api")
+        self.assertEqual(updated["metrics_updated"], "2026-08-01")
+
+    def test_fetch_all_strict_fails_before_writes_for_known_zero_metrics(self):
+        """Treat zero as known and abort strict refreshes before any write."""
+        with TemporaryDirectory() as tmp_dir:
+            papers_dir = Path(tmp_dir) / "papers"
+            papers_dir.mkdir()
+            paper_path = papers_dir / "zero-metrics.yaml"
+            original = (
+                "title: Zero Metrics\n"
+                "year: 2026\n"
+                "links:\n"
+                "  arxiv: https://arxiv.org/abs/2601.00001\n"
+                "  github: https://github.com/owner/repo\n"
+                "citations: 0\n"
+                "github_stars: 0\n"
+                "metrics_updated: '2026-08-01'\n"
+            ).encode()
+            paper_path.write_bytes(original)
+
+            with (
+                mock.patch.object(fetch_metrics, "PAPERS_DIR", papers_dir),
+                mock.patch.object(fetch_metrics, "CACHE_FILE", Path(tmp_dir) / "cache.json"),
+                mock.patch.object(
+                    fetch_metrics,
+                    "GITHUB_LINK_REPORT_FILE",
+                    Path(tmp_dir) / "github-links.json",
+                ),
+                mock.patch.object(fetch_metrics, "fetch_citations_semantic_scholar", return_value={}),
+                mock.patch.object(fetch_metrics, "fetch_citations_openalex", return_value={}),
+                mock.patch.object(fetch_metrics, "fetch_citations_opencitations", return_value={}),
+                mock.patch.object(fetch_metrics, "fetch_citations_crossref", return_value={}),
+                mock.patch.object(fetch_metrics, "fetch_stars_parallel", return_value=({}, {}, [])),
+                mock.patch.object(fetch_metrics, "_save_metrics_cache") as cache_writer,
+                mock.patch.object(fetch_metrics, "_save_github_link_report") as report_writer,
+            ):
+                with self.assertRaises(RuntimeError) as raised:
+                    fetch_metrics.fetch_all(progress=False, strict=True)
+
+            updated_bytes = paper_path.read_bytes()
+
+        self.assertIn("zero-metrics: citations", str(raised.exception))
+        self.assertIn("zero-metrics: github_stars", str(raised.exception))
+        self.assertEqual(updated_bytes, original)
+        cache_writer.assert_not_called()
+        report_writer.assert_not_called()
+
+    def test_fetch_all_strict_allows_new_paper_without_metrics(self):
+        """Allow strict refreshes when a new paper has no known metric values."""
+        with TemporaryDirectory() as tmp_dir:
+            papers_dir = Path(tmp_dir) / "papers"
+            papers_dir.mkdir()
+            paper_path = papers_dir / "new-paper.yaml"
+            original = (
+                "title: New Paper\n"
+                "year: 2026\n"
+                "links:\n"
+                "  arxiv: https://arxiv.org/abs/2601.00002\n"
+                "  github: https://github.com/owner/new-repo\n"
+            ).encode()
+            paper_path.write_bytes(original)
+
+            with (
+                mock.patch.object(fetch_metrics, "PAPERS_DIR", papers_dir),
+                mock.patch.object(fetch_metrics, "CACHE_FILE", Path(tmp_dir) / "cache.json"),
+                mock.patch.object(
+                    fetch_metrics,
+                    "GITHUB_LINK_REPORT_FILE",
+                    Path(tmp_dir) / "github-links.json",
+                ),
+                mock.patch.object(fetch_metrics, "fetch_citations_semantic_scholar", return_value={}),
+                mock.patch.object(fetch_metrics, "fetch_citations_openalex", return_value={}),
+                mock.patch.object(fetch_metrics, "fetch_citations_opencitations", return_value={}),
+                mock.patch.object(fetch_metrics, "fetch_citations_crossref", return_value={}),
+                mock.patch.object(fetch_metrics, "fetch_stars_parallel", return_value=({}, {}, [])),
+                mock.patch.object(fetch_metrics, "_save_metrics_cache") as cache_writer,
+                mock.patch.object(fetch_metrics, "_save_github_link_report") as report_writer,
+            ):
+                fetch_metrics.fetch_all(progress=False, strict=True)
+
+            updated_bytes = paper_path.read_bytes()
+
+        self.assertEqual(updated_bytes, original)
+        cache_writer.assert_called_once()
+        report_writer.assert_called_once()
+
     def test_load_dotenv_file_sets_missing_values_only(self):
         with TemporaryDirectory() as tmp_dir:
             env_file = Path(tmp_dir) / ".env"

--- a/tests/test_fetch_metrics.py
+++ b/tests/test_fetch_metrics.py
@@ -425,7 +425,15 @@ class SemanticScholarFetchTests(unittest.TestCase):
                 mock.patch.object(fetch_metrics, "fetch_citations_openalex", return_value={}),
                 mock.patch.object(fetch_metrics, "fetch_citations_opencitations", return_value={}),
                 mock.patch.object(fetch_metrics, "fetch_citations_crossref", return_value={}),
-                mock.patch.object(fetch_metrics, "fetch_stars_parallel", return_value=({}, {}, [])),
+                mock.patch.object(
+                    fetch_metrics,
+                    "fetch_stars_parallel",
+                    return_value=(
+                        {"legacy-paper": 40},
+                        {"legacy-paper": {"github_html": 40}},
+                        [],
+                    ),
+                ),
                 mock.patch.object(
                     fetch_metrics,
                     "_utcnow",
@@ -444,11 +452,11 @@ class SemanticScholarFetchTests(unittest.TestCase):
         self.assertNotEqual(updated_bytes, original)
         self.assertEqual(updated["citations"], 7)
         self.assertEqual(updated["citation_sources"], {"semantic_scholar": 6})
-        self.assertEqual(updated["citation_source_best"], "semantic_scholar")
+        self.assertNotIn("citation_source_best", updated)
         self.assertEqual(updated["github_stars"], 42)
-        self.assertEqual(updated["metrics_updated"], "2026-09-03")
-        self.assertNotIn("star_sources", updated)
+        self.assertEqual(updated["star_sources"], {"github_html": 40})
         self.assertNotIn("star_source_best", updated)
+        self.assertEqual(updated["metrics_updated"], "2026-09-03")
         self.assertEqual(outage_bytes, outage_original)
         self.assertEqual(outage["metrics_updated"], "2026-08-02")
         self.assertNotIn("citation_sources", outage)
@@ -539,7 +547,7 @@ class SemanticScholarFetchTests(unittest.TestCase):
 
         self.assertEqual(updated_bytes, original)
         cache_loader.assert_not_called()
-        cache_writer.assert_called_once()
+        cache_writer.assert_not_called()
         report_writer.assert_called_once()
 
     def test_load_dotenv_file_sets_missing_values_only(self):

--- a/tests/test_fetch_metrics.py
+++ b/tests/test_fetch_metrics.py
@@ -308,8 +308,8 @@ class SemanticScholarFetchTests(unittest.TestCase):
         self.assertEqual(updated["citation_source_best"], "openalex")
         self.assertEqual(cache_data["version"], 1)
 
-    def test_fetch_all_applies_source_corrections_and_preserves_failed_provenance(self):
-        """Apply lower same-source values while retaining failed-source provenance."""
+    def test_fetch_all_applies_source_corrections_and_preserves_failed_citation_provenance(self):
+        """Apply fresh corrections while retaining failed citation provenance."""
         with TemporaryDirectory() as tmp_dir:
             papers_dir = Path(tmp_dir) / "papers"
             papers_dir.mkdir()
@@ -379,12 +379,9 @@ class SemanticScholarFetchTests(unittest.TestCase):
             {"semantic_scholar": 5, "openalex": 6},
         )
         self.assertEqual(updated["citation_source_best"], "openalex")
-        self.assertEqual(updated["github_stars"], 41)
-        self.assertEqual(
-            updated["star_sources"],
-            {"github_api": 40, "github_html": 41},
-        )
-        self.assertEqual(updated["star_source_best"], "github_html")
+        self.assertEqual(updated["github_stars"], 40)
+        self.assertEqual(updated["star_sources"], {"github_api": 40})
+        self.assertEqual(updated["star_source_best"], "github_api")
         self.assertEqual(updated["metrics_updated"], "2026-09-03")
 
     def test_fetch_all_preserves_legacy_aggregates_during_partial_and_total_outages(self):
@@ -434,9 +431,6 @@ class SemanticScholarFetchTests(unittest.TestCase):
                 "  semantic_scholar: 8\n"
                 "citation_source_best: semantic_scholar\n"
                 "github_stars: 50\n"
-                "star_sources:\n"
-                "  github_api: 45\n"
-                "star_source_best: github_api\n"
                 "metrics_updated: '2026-08-03'\n"
             ).encode()
             unsupported_path.write_bytes(unsupported_original)
@@ -490,9 +484,9 @@ class SemanticScholarFetchTests(unittest.TestCase):
         self.assertEqual(updated["citations"], 7)
         self.assertEqual(updated["citation_sources"], {"semantic_scholar": 6})
         self.assertNotIn("citation_source_best", updated)
-        self.assertEqual(updated["github_stars"], 42)
+        self.assertEqual(updated["github_stars"], 40)
         self.assertEqual(updated["star_sources"], {"github_html": 40})
-        self.assertNotIn("star_source_best", updated)
+        self.assertEqual(updated["star_source_best"], "github_html")
         self.assertEqual(updated["metrics_updated"], "2026-09-03")
         self.assertEqual(outage_bytes, outage_original)
         self.assertEqual(outage["metrics_updated"], "2026-08-02")
@@ -504,9 +498,9 @@ class SemanticScholarFetchTests(unittest.TestCase):
         self.assertEqual(unsupported["citations"], 10)
         self.assertEqual(unsupported["citation_sources"], {"semantic_scholar": 7})
         self.assertNotIn("citation_source_best", unsupported)
-        self.assertEqual(unsupported["github_stars"], 50)
+        self.assertEqual(unsupported["github_stars"], 44)
         self.assertEqual(unsupported["star_sources"], {"github_api": 44})
-        self.assertNotIn("star_source_best", unsupported)
+        self.assertEqual(unsupported["star_source_best"], "github_api")
         self.assertEqual(unsupported["metrics_updated"], "2026-09-03")
 
     def test_fetch_all_strict_fails_before_writes_for_known_zero_metrics(self):

--- a/tests/test_fetch_metrics.py
+++ b/tests/test_fetch_metrics.py
@@ -308,8 +308,8 @@ class SemanticScholarFetchTests(unittest.TestCase):
         self.assertEqual(updated["citation_source_best"], "openalex")
         self.assertEqual(cache_data["version"], 1)
 
-    def test_fetch_all_preserves_metrics_and_provenance_during_source_outages(self):
-        """Merge a fresh citation while retaining failed-source provenance."""
+    def test_fetch_all_applies_source_corrections_and_preserves_failed_provenance(self):
+        """Apply lower same-source values while retaining failed-source provenance."""
         with TemporaryDirectory() as tmp_dir:
             papers_dir = Path(tmp_dir) / "papers"
             papers_dir.mkdir()
@@ -320,9 +320,9 @@ class SemanticScholarFetchTests(unittest.TestCase):
                 "links:\n"
                 "  arxiv: https://arxiv.org/abs/2403.09629\n"
                 "  github: https://github.com/owner/repo\n"
-                "citations: 7\n"
+                "citations: 9\n"
                 "citation_sources:\n"
-                "  semantic_scholar: 7\n"
+                "  semantic_scholar: 9\n"
                 "  openalex: 6\n"
                 "citation_source_best: semantic_scholar\n"
                 "github_stars: 42\n"
@@ -345,12 +345,20 @@ class SemanticScholarFetchTests(unittest.TestCase):
                 mock.patch.object(
                     fetch_metrics,
                     "fetch_citations_semantic_scholar",
-                    return_value={"2403.09629": 8},
+                    return_value={"2403.09629": 5},
                 ),
                 mock.patch.object(fetch_metrics, "fetch_citations_openalex", return_value={}),
                 mock.patch.object(fetch_metrics, "fetch_citations_opencitations", return_value={}),
                 mock.patch.object(fetch_metrics, "fetch_citations_crossref", return_value={}),
-                mock.patch.object(fetch_metrics, "fetch_stars_parallel", return_value=({}, {}, [])),
+                mock.patch.object(
+                    fetch_metrics,
+                    "fetch_stars_parallel",
+                    return_value=(
+                        {"2403.09629": 40},
+                        {"2403.09629": {"github_api": 40}},
+                        [],
+                    ),
+                ),
                 mock.patch.object(
                     fetch_metrics,
                     "_utcnow",
@@ -365,18 +373,18 @@ class SemanticScholarFetchTests(unittest.TestCase):
             updated = fetch_metrics.yaml.safe_load(updated_bytes)
 
         self.assertNotEqual(updated_bytes, original)
-        self.assertEqual(updated["citations"], 8)
+        self.assertEqual(updated["citations"], 6)
         self.assertEqual(
             updated["citation_sources"],
-            {"semantic_scholar": 8, "openalex": 6},
+            {"semantic_scholar": 5, "openalex": 6},
         )
-        self.assertEqual(updated["citation_source_best"], "semantic_scholar")
-        self.assertEqual(updated["github_stars"], 42)
+        self.assertEqual(updated["citation_source_best"], "openalex")
+        self.assertEqual(updated["github_stars"], 41)
         self.assertEqual(
             updated["star_sources"],
-            {"github_api": 42, "github_html": 41},
+            {"github_api": 40, "github_html": 41},
         )
-        self.assertEqual(updated["star_source_best"], "github_api")
+        self.assertEqual(updated["star_source_best"], "github_html")
         self.assertEqual(updated["metrics_updated"], "2026-09-03")
 
     def test_fetch_all_preserves_legacy_aggregates_during_partial_and_total_outages(self):

--- a/tests/test_fetch_metrics.py
+++ b/tests/test_fetch_metrics.py
@@ -388,7 +388,7 @@ class SemanticScholarFetchTests(unittest.TestCase):
         self.assertEqual(updated["metrics_updated"], "2026-09-03")
 
     def test_fetch_all_preserves_legacy_aggregates_during_partial_and_total_outages(self):
-        """Retain aggregate-only metrics across lower results and total outages."""
+        """Retain unsupported legacy metrics across lower results and outages."""
         with TemporaryDirectory() as tmp_dir:
             papers_dir = Path(tmp_dir) / "papers"
             papers_dir.mkdir()
@@ -416,6 +416,22 @@ class SemanticScholarFetchTests(unittest.TestCase):
                 "metrics_updated: '2026-08-02'\n"
             ).encode()
             outage_path.write_bytes(outage_original)
+            unsupported_path = papers_dir / "unsupported-paper.yaml"
+            unsupported_original = (
+                "title: Unsupported Legacy Metrics\n"
+                "year: 2024\n"
+                "links:\n"
+                "  arxiv: https://arxiv.org/abs/2403.09631\n"
+                "  github: https://github.com/owner/unsupported\n"
+                "citations: 10\n"
+                "citation_sources:\n"
+                "  semantic_scholar: 8\n"
+                "github_stars: 50\n"
+                "star_sources:\n"
+                "  github_api: 45\n"
+                "metrics_updated: '2026-08-03'\n"
+            ).encode()
+            unsupported_path.write_bytes(unsupported_original)
 
             with (
                 mock.patch.object(fetch_metrics, "PAPERS_DIR", papers_dir),
@@ -428,7 +444,7 @@ class SemanticScholarFetchTests(unittest.TestCase):
                 mock.patch.object(
                     fetch_metrics,
                     "fetch_citations_semantic_scholar",
-                    return_value={"legacy-paper": 6},
+                    return_value={"legacy-paper": 6, "unsupported-paper": 7},
                 ),
                 mock.patch.object(fetch_metrics, "fetch_citations_openalex", return_value={}),
                 mock.patch.object(fetch_metrics, "fetch_citations_opencitations", return_value={}),
@@ -437,8 +453,11 @@ class SemanticScholarFetchTests(unittest.TestCase):
                     fetch_metrics,
                     "fetch_stars_parallel",
                     return_value=(
-                        {"legacy-paper": 40},
-                        {"legacy-paper": {"github_html": 40}},
+                        {"legacy-paper": 40, "unsupported-paper": 44},
+                        {
+                            "legacy-paper": {"github_html": 40},
+                            "unsupported-paper": {"github_api": 44},
+                        },
                         [],
                     ),
                 ),
@@ -456,6 +475,8 @@ class SemanticScholarFetchTests(unittest.TestCase):
             updated = fetch_metrics.yaml.safe_load(updated_bytes)
             outage_bytes = outage_path.read_bytes()
             outage = fetch_metrics.yaml.safe_load(outage_bytes)
+            unsupported_bytes = unsupported_path.read_bytes()
+            unsupported = fetch_metrics.yaml.safe_load(unsupported_bytes)
 
         self.assertNotEqual(updated_bytes, original)
         self.assertEqual(updated["citations"], 7)
@@ -471,6 +492,14 @@ class SemanticScholarFetchTests(unittest.TestCase):
         self.assertNotIn("citation_source_best", outage)
         self.assertNotIn("star_sources", outage)
         self.assertNotIn("star_source_best", outage)
+        self.assertNotEqual(unsupported_bytes, unsupported_original)
+        self.assertEqual(unsupported["citations"], 10)
+        self.assertEqual(unsupported["citation_sources"], {"semantic_scholar": 7})
+        self.assertNotIn("citation_source_best", unsupported)
+        self.assertEqual(unsupported["github_stars"], 50)
+        self.assertEqual(unsupported["star_sources"], {"github_api": 44})
+        self.assertNotIn("star_source_best", unsupported)
+        self.assertEqual(unsupported["metrics_updated"], "2026-09-03")
 
     def test_fetch_all_strict_fails_before_writes_for_known_zero_metrics(self):
         """Treat zero as known and abort strict refreshes before any write."""

--- a/tests/test_fetch_metrics.py
+++ b/tests/test_fetch_metrics.py
@@ -426,9 +426,11 @@ class SemanticScholarFetchTests(unittest.TestCase):
                 "citations: 10\n"
                 "citation_sources:\n"
                 "  semantic_scholar: 8\n"
+                "citation_source_best: semantic_scholar\n"
                 "github_stars: 50\n"
                 "star_sources:\n"
                 "  github_api: 45\n"
+                "star_source_best: github_api\n"
                 "metrics_updated: '2026-08-03'\n"
             ).encode()
             unsupported_path.write_bytes(unsupported_original)

--- a/tests/test_fetch_metrics.py
+++ b/tests/test_fetch_metrics.py
@@ -379,8 +379,8 @@ class SemanticScholarFetchTests(unittest.TestCase):
         self.assertEqual(updated["star_source_best"], "github_api")
         self.assertEqual(updated["metrics_updated"], "2026-09-03")
 
-    def test_fetch_all_total_outage_leaves_legacy_aggregate_only_yaml_unchanged(self):
-        """Leave aggregate-only legacy metrics byte-stable on total outage."""
+    def test_fetch_all_preserves_legacy_aggregates_during_partial_and_total_outages(self):
+        """Retain aggregate-only metrics across lower results and total outages."""
         with TemporaryDirectory() as tmp_dir:
             papers_dir = Path(tmp_dir) / "papers"
             papers_dir.mkdir()
@@ -396,6 +396,18 @@ class SemanticScholarFetchTests(unittest.TestCase):
                 "metrics_updated: '2026-08-01'\n"
             ).encode()
             paper_path.write_bytes(original)
+            outage_path = papers_dir / "outage-paper.yaml"
+            outage_original = (
+                "title: Outage Paper\n"
+                "year: 2024\n"
+                "links:\n"
+                "  arxiv: https://arxiv.org/abs/2403.09630\n"
+                "  github: https://github.com/owner/outage\n"
+                "citations: 3\n"
+                "github_stars: 5\n"
+                "metrics_updated: '2026-08-02'\n"
+            ).encode()
+            outage_path.write_bytes(outage_original)
 
             with (
                 mock.patch.object(fetch_metrics, "PAPERS_DIR", papers_dir),
@@ -405,11 +417,20 @@ class SemanticScholarFetchTests(unittest.TestCase):
                     "GITHUB_LINK_REPORT_FILE",
                     Path(tmp_dir) / "github-links.json",
                 ),
-                mock.patch.object(fetch_metrics, "fetch_citations_semantic_scholar", return_value={}),
+                mock.patch.object(
+                    fetch_metrics,
+                    "fetch_citations_semantic_scholar",
+                    return_value={"legacy-paper": 6},
+                ),
                 mock.patch.object(fetch_metrics, "fetch_citations_openalex", return_value={}),
                 mock.patch.object(fetch_metrics, "fetch_citations_opencitations", return_value={}),
                 mock.patch.object(fetch_metrics, "fetch_citations_crossref", return_value={}),
                 mock.patch.object(fetch_metrics, "fetch_stars_parallel", return_value=({}, {}, [])),
+                mock.patch.object(
+                    fetch_metrics,
+                    "_utcnow",
+                    return_value=datetime(2026, 9, 3, tzinfo=timezone.utc),
+                ),
                 mock.patch.object(fetch_metrics, "_save_metrics_cache"),
                 mock.patch.object(fetch_metrics, "_save_github_link_report"),
             ):
@@ -417,15 +438,23 @@ class SemanticScholarFetchTests(unittest.TestCase):
 
             updated_bytes = paper_path.read_bytes()
             updated = fetch_metrics.yaml.safe_load(updated_bytes)
+            outage_bytes = outage_path.read_bytes()
+            outage = fetch_metrics.yaml.safe_load(outage_bytes)
 
-        self.assertEqual(updated_bytes, original)
+        self.assertNotEqual(updated_bytes, original)
         self.assertEqual(updated["citations"], 7)
+        self.assertEqual(updated["citation_sources"], {"semantic_scholar": 6})
+        self.assertEqual(updated["citation_source_best"], "semantic_scholar")
         self.assertEqual(updated["github_stars"], 42)
-        self.assertEqual(updated["metrics_updated"], "2026-08-01")
-        self.assertNotIn("citation_sources", updated)
-        self.assertNotIn("citation_source_best", updated)
+        self.assertEqual(updated["metrics_updated"], "2026-09-03")
         self.assertNotIn("star_sources", updated)
         self.assertNotIn("star_source_best", updated)
+        self.assertEqual(outage_bytes, outage_original)
+        self.assertEqual(outage["metrics_updated"], "2026-08-02")
+        self.assertNotIn("citation_sources", outage)
+        self.assertNotIn("citation_source_best", outage)
+        self.assertNotIn("star_sources", outage)
+        self.assertNotIn("star_source_best", outage)
 
     def test_fetch_all_strict_fails_before_writes_for_known_zero_metrics(self):
         """Treat zero as known and abort strict refreshes before any write."""
@@ -500,6 +529,7 @@ class SemanticScholarFetchTests(unittest.TestCase):
                 mock.patch.object(fetch_metrics, "fetch_citations_opencitations", return_value={}),
                 mock.patch.object(fetch_metrics, "fetch_citations_crossref", return_value={}),
                 mock.patch.object(fetch_metrics, "fetch_stars_parallel", return_value=({}, {}, [])),
+                mock.patch.object(fetch_metrics, "_load_metrics_cache") as cache_loader,
                 mock.patch.object(fetch_metrics, "_save_metrics_cache") as cache_writer,
                 mock.patch.object(fetch_metrics, "_save_github_link_report") as report_writer,
             ):
@@ -508,6 +538,7 @@ class SemanticScholarFetchTests(unittest.TestCase):
             updated_bytes = paper_path.read_bytes()
 
         self.assertEqual(updated_bytes, original)
+        cache_loader.assert_not_called()
         cache_writer.assert_called_once()
         report_writer.assert_called_once()
 


### PR DESCRIPTION
## Summary

- make the scheduled metrics workflow the sole writer, with daily and post-merge refreshes plus strict no-stale-write checks
- preserve citation/star provenance across outages while treating the current GitHub API/HTML transport as authoritative for stars
- rename the Today filter to Newly Arrived using the latest valid paper `added_date`, and align the paper-watch countdown with the 20:15 ET schedule

## Verification

- [x] `git diff --check origin/main...HEAD`
- [x] two independent static code/config reviews: no Critical, Important, or Minor findings
- [ ] GitHub Actions build, asset budgets, and unit tests

Local build/tests were not run because this checkout follows the shared Slurm execution policy; GitHub Actions is the test authority for this PR.