### PR TITLE
Restore live Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1611,7 +1611,10 @@ If you find this repository useful, please consider citing this list:
 
 ## Star History
 
-![Star history of huskydoge/Awesome-Loop-Models](assets/star-history/star-history.png)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=huskydoge%2Fawesome-loop-models&type=date&theme=dark">
+  <img alt="Star history of huskydoge/Awesome-Loop-Models" src="https://api.star-history.com/svg?repos=huskydoge%2Fawesome-loop-models&type=date">
+</picture>
 
 ---
 

--- a/scripts/README_FOOTER.md
+++ b/scripts/README_FOOTER.md
@@ -35,7 +35,10 @@ If you find this repository useful, please consider citing this list:
 
 ## Star History
 
-![Star history of huskydoge/Awesome-Loop-Models](assets/star-history/star-history.png)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=huskydoge%2Fawesome-loop-models&type=date&theme=dark">
+  <img alt="Star history of huskydoge/Awesome-Loop-Models" src="https://api.star-history.com/svg?repos=huskydoge%2Fawesome-loop-models&type=date">
+</picture>
 
 ---
 


### PR DESCRIPTION
## Summary
- replace the stale checked-in Star History PNG with the live Star History SVG
- provide light and dark variants through the existing README footer template
- keep the generated README synchronized with its source template

## Verification
- verified both live SVG endpoints return HTTP 200 with `image/svg+xml`
- verified the README footer and generated README Star History sections match
- `git diff --check`

Test suite not run locally per repository execution policy; this documentation-only change does not modify runtime code.